### PR TITLE
Schema-first tool registry as single source of truth

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,11 +10,11 @@ test:
 
 # Run spell checking
 spell:
-	uv run codespell --skip=metaData,notebooks,htmlcov --ignore-words-list=EHR
+	uv run codespell --skip=metaData,notebooks,htmlcov,PathFinder_results --ignore-words-list=EHR
 
 # Run spell checking interactively (allows fixing)
 spell-fix:
-	uv run codespell --interactive 3 --skip=metaData,notebooks,htmlcov --ignore-words-list=EHR
+	uv run codespell --interactive 3 --skip=metaData,notebooks,htmlcov,PathFinder_results --ignore-words-list=EHR
 
 # Run linting
 lint:

--- a/src/translator_component_toolkit/schema.py
+++ b/src/translator_component_toolkit/schema.py
@@ -1,0 +1,347 @@
+"""
+Schema-first tool registry for the Translator Component Toolkit.
+
+This module is the single source of truth for every agent-facing operation.
+The MCP server (and, in later work, the CLI) are generated from ``REGISTRY``
+rather than hand-wrapping library functions per surface, so names, parameters,
+and descriptions stay in lockstep across surfaces.
+
+A :class:`ToolSpec` describes one operation: its canonical name, a one-line
+summary, its parameters (:class:`ParamSpec`), the adapter callable that invokes
+the underlying library function, optional deprecated aliases, and a command
+group used to organize the CLI.
+"""
+
+from __future__ import annotations
+
+import inspect
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+from . import name_resolver, node_normalizer, translator_kpinfo, translator_metakg, translator_query, trapi
+
+
+@dataclass(frozen=True)
+class ParamSpec:
+    """One parameter of a tool.
+
+    Attributes
+    ----------
+    name : str
+        Parameter name as exposed on every surface.
+    type : Any
+        Python type annotation used to build the MCP/CLI schema.
+    required : bool
+        Whether the parameter must be supplied.
+    default : Any
+        Default value when ``required`` is False.
+    help : str
+        Human/agent-facing description.
+    choices : list | None
+        Enumerated valid values, if the parameter is constrained.
+    """
+
+    name: str
+    type: Any = Any
+    required: bool = False
+    default: Any = None
+    help: str = ""
+    choices: list[Any] | None = None
+
+
+@dataclass(frozen=True)
+class ToolSpec:
+    """One agent-facing operation.
+
+    Attributes
+    ----------
+    name : str
+        Canonical tool name.
+    summary : str
+        One-line description shown to humans and agents.
+    func : Callable
+        Adapter that accepts the ``ParamSpec`` names as keyword arguments and
+        delegates to the underlying library function.
+    params : list[ParamSpec]
+        Ordered parameter specifications.
+    aliases : list[str]
+        Deprecated alternative names kept for backwards compatibility.
+    group : str
+        CLI command group (e.g. ``name``, ``query``).
+    output_hint : str | None
+        Optional note about the return shape.
+    """
+
+    name: str
+    summary: str
+    func: Callable[..., Any]
+    params: list[ParamSpec] = field(default_factory=list)
+    aliases: list[str] = field(default_factory=list)
+    group: str = "misc"
+    output_hint: str | None = None
+
+
+def make_signed_callable(spec: ToolSpec) -> Callable[..., Any]:
+    """Build a callable whose signature/annotations match ``spec``.
+
+    FastMCP and Click both introspect ``inspect.signature``; constructing a
+    wrapper with an explicit ``__signature__`` lets a single registry entry
+    drive both surfaces without duplicating parameter declarations.
+    """
+    parameters = []
+    annotations: dict[str, Any] = {}
+    for p in spec.params:
+        annotations[p.name] = p.type
+        default = inspect.Parameter.empty if p.required else p.default
+        parameters.append(
+            inspect.Parameter(
+                p.name,
+                inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                default=default,
+                annotation=p.type,
+            )
+        )
+    signature = inspect.Signature(parameters)
+    func = spec.func
+
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        bound = signature.bind(*args, **kwargs)
+        bound.apply_defaults()
+        return func(**bound.arguments)
+
+    wrapper.__name__ = spec.name
+    wrapper.__qualname__ = spec.name
+    wrapper.__doc__ = spec.summary
+    wrapper.__signature__ = signature  # type: ignore[attr-defined]
+    wrapper.__annotations__ = {**annotations, "return": Any}
+    return wrapper
+
+
+# ---------------------------------------------------------------------------
+# Adapters: each accepts ParamSpec-named kwargs and delegates to the library,
+# isolating the library's notebook-style parameter names from the public API.
+# ---------------------------------------------------------------------------
+
+def _name_lookup(query: str, return_top_response: bool = True, return_synonyms: bool = False) -> Any:
+    return name_resolver.lookup(query, return_top_response, return_synonyms)
+
+
+def _get_name_synonyms(query: str) -> Any:
+    return name_resolver.synonyms(query)
+
+
+def _batch_name_lookup(strings: list[str], size: int = 25, return_top_response: bool = True,
+                       return_synonyms: bool = False) -> Any:
+    return name_resolver.batch_lookup(strings, size, return_top_response, return_synonyms)
+
+
+def _normalize_nodes(query: str, return_equivalent_identifiers: bool = False, conflate: bool = True,
+                     drug_chemical_conflate: bool = False) -> Any:
+    return node_normalizer.get_normalized_nodes(
+        query, return_equivalent_identifiers, conflate=conflate, drug_chemical_conflate=drug_chemical_conflate
+    )
+
+
+def _get_kp_info() -> Any:
+    return translator_kpinfo.get_translator_kp_info()
+
+
+def _get_metakg_data(api_names: dict) -> Any:
+    return translator_metakg.get_KP_metadata(api_names)
+
+
+def _add_custom_api_to_metakg(api_names: dict, metakg_df: Any, new_api_name: str, new_api_url: str,
+                              new_api_predicate: str, new_api_subject: str, new_api_object: str) -> Any:
+    return translator_metakg.add_new_API_for_query(
+        api_names, metakg_df, new_api_name, new_api_url, new_api_predicate, new_api_subject, new_api_object
+    )
+
+
+def _add_plover_apis_to_metakg(api_names: dict, metakg_df: Any) -> Any:
+    return translator_metakg.add_plover_API(api_names, metakg_df)
+
+
+def _get_api_predicates() -> Any:
+    return translator_query.get_translator_API_predicates()
+
+
+def _optimize_query_for_api(query_json: dict, api_name: str, api_predicates: dict) -> Any:
+    return translator_query.optimize_query_json(query_json, api_name, api_predicates)
+
+
+def _query_knowledge_provider(api_name: str, query_json: dict, api_names: dict, api_predicates: dict) -> Any:
+    return translator_query.query_KP(api_name, query_json, api_names, api_predicates)
+
+
+def _parallel_query_apis(query_json: dict, selected_apis: list[str], api_names: dict, api_predicates: dict,
+                         max_workers: int = 1) -> Any:
+    return translator_query.parallel_api_query(query_json, selected_apis, api_names, api_predicates, max_workers)
+
+
+def _trapi_query_endpoint(url: str, query: dict) -> Any:
+    return trapi.query(url, query)
+
+
+# ---------------------------------------------------------------------------
+# Registry: the single source of truth.
+# ---------------------------------------------------------------------------
+
+REGISTRY: list[ToolSpec] = [
+    ToolSpec(
+        name="name_lookup",
+        summary="Look up a name/term and return normalized TranslatorNode information.",
+        func=_name_lookup,
+        group="name",
+        params=[
+            ParamSpec("query", str, required=True, help="Query string to look up."),
+            ParamSpec("return_top_response", bool, default=True,
+                      help="Return only the top response (True) or all responses (False)."),
+            ParamSpec("return_synonyms", bool, default=False, help="Include synonyms in the result."),
+        ],
+        output_hint="TranslatorNode or list[TranslatorNode]",
+    ),
+    ToolSpec(
+        name="get_name_synonyms",
+        summary="Get synonyms for a given CURIE.",
+        func=_get_name_synonyms,
+        group="name",
+        params=[ParamSpec("query", str, required=True, help="CURIE to get synonyms for.")],
+        output_hint="dict[curie, TranslatorNode]",
+    ),
+    ToolSpec(
+        name="batch_name_lookup",
+        summary="Batch look up multiple names/terms and return normalized TranslatorNode information.",
+        func=_batch_name_lookup,
+        group="name",
+        params=[
+            ParamSpec("strings", list[str], required=True, help="List of query strings."),
+            ParamSpec("size", int, default=25, help="Chunking size for batch processing."),
+            ParamSpec("return_top_response", bool, default=True, help="Return only the top response per string."),
+            ParamSpec("return_synonyms", bool, default=False, help="Include synonyms in the results."),
+        ],
+        output_hint="dict[str, TranslatorNode]",
+    ),
+    ToolSpec(
+        name="normalize_nodes",
+        summary="Normalize node CURIEs using the Node Normalizer API.",
+        func=_normalize_nodes,
+        group="normalize",
+        params=[
+            ParamSpec("query", str, required=True, help="CURIE string or list of CURIEs to normalize."),
+            ParamSpec("return_equivalent_identifiers", bool, default=False,
+                      help="Whether to return equivalent identifiers."),
+            ParamSpec("conflate", bool, default=True, help="Enable gene-protein conflation."),
+            ParamSpec("drug_chemical_conflate", bool, default=False, help="Enable drug-chemical conflation."),
+        ],
+        output_hint="TranslatorNode or dict[curie, TranslatorNode]",
+    ),
+    ToolSpec(
+        name="get_kp_info",
+        summary="Get SmartAPI Translator Knowledge Provider information.",
+        func=_get_kp_info,
+        group="kp",
+        output_hint="tuple[DataFrame, dict[name, url]]",
+    ),
+    ToolSpec(
+        name="get_metakg_data",
+        summary="Get MetaKG metadata (predicates, subjects, objects) for Knowledge Providers.",
+        func=_get_metakg_data,
+        group="metakg",
+        params=[ParamSpec("api_names", dict, required=True, help="Dictionary mapping API names to URLs.")],
+        output_hint="DataFrame",
+    ),
+    ToolSpec(
+        name="add_custom_api_to_metakg",
+        summary="Add a custom API to the knowledge graph metadata.",
+        func=_add_custom_api_to_metakg,
+        group="metakg",
+        params=[
+            ParamSpec("api_names", dict, required=True, help="Current API names dictionary."),
+            ParamSpec("metakg_df", Any, required=True, help="Current MetaKG DataFrame."),
+            ParamSpec("new_api_name", str, required=True, help="Name of the new API."),
+            ParamSpec("new_api_url", str, required=True, help="URL of the new API."),
+            ParamSpec("new_api_predicate", str, required=True, help="Predicate for the new API."),
+            ParamSpec("new_api_subject", str, required=True, help="Subject type for the new API."),
+            ParamSpec("new_api_object", str, required=True, help="Object type for the new API."),
+        ],
+        output_hint="tuple[dict, DataFrame]",
+    ),
+    ToolSpec(
+        name="add_plover_apis_to_metakg",
+        summary="Add Plover APIs (CATRAX team APIs) to the knowledge graph metadata.",
+        func=_add_plover_apis_to_metakg,
+        group="metakg",
+        params=[
+            ParamSpec("api_names", dict, required=True, help="Current API names dictionary."),
+            ParamSpec("metakg_df", Any, required=True, help="Current MetaKG DataFrame."),
+        ],
+        output_hint="tuple[dict, DataFrame]",
+    ),
+    ToolSpec(
+        name="get_api_predicates",
+        summary="Get the predicates supported by each Translator API.",
+        func=_get_api_predicates,
+        group="query",
+        output_hint="tuple[dict, DataFrame, dict]",
+    ),
+    ToolSpec(
+        name="optimize_query_for_api",
+        summary="Remove predicates from a TRAPI query that the selected API does not support.",
+        func=_optimize_query_for_api,
+        group="query",
+        params=[
+            ParamSpec("query_json", dict, required=True, help="TRAPI 1.5.0 format query."),
+            ParamSpec("api_name", str, required=True, help="Name of the API to query."),
+            ParamSpec("api_predicates", dict, required=True, help="Dictionary of API names to their predicates."),
+        ],
+        output_hint="dict (modified query)",
+    ),
+    ToolSpec(
+        name="query_knowledge_provider",
+        summary="Query an individual Knowledge Provider API with a TRAPI 1.5.0 query.",
+        func=_query_knowledge_provider,
+        group="query",
+        params=[
+            ParamSpec("api_name", str, required=True, help="Name of the API to query."),
+            ParamSpec("query_json", dict, required=True, help="TRAPI 1.5.0 format query."),
+            ParamSpec("api_names", dict, required=True, help="Dictionary mapping API names to URLs."),
+            ParamSpec("api_predicates", dict, required=True, help="Dictionary of API names to their predicates."),
+        ],
+        output_hint="dict (knowledge graph) or None",
+    ),
+    ToolSpec(
+        name="parallel_query_apis",
+        summary="Query multiple APIs in parallel and merge results into a single knowledge graph.",
+        func=_parallel_query_apis,
+        group="query",
+        params=[
+            ParamSpec("query_json", dict, required=True, help="TRAPI 1.5.0 format query."),
+            ParamSpec("selected_apis", list[str], required=True, help="List of API names to query."),
+            ParamSpec("api_names", dict, required=True, help="Dictionary mapping API names to URLs."),
+            ParamSpec("api_predicates", dict, required=True, help="Dictionary of API names to their predicates."),
+            ParamSpec("max_workers", int, default=1, help="Number of parallel workers."),
+        ],
+        output_hint="dict (merged knowledge graph)",
+    ),
+    ToolSpec(
+        name="trapi_query_endpoint",
+        summary="Query a TRAPI endpoint with a TRAPI query and return the result message.",
+        func=_trapi_query_endpoint,
+        group="trapi",
+        params=[
+            ParamSpec("url", str, required=True, help="URL of the TRAPI endpoint."),
+            ParamSpec("query", dict, required=True, help="TRAPI query dict (e.g. from trapi.build_query)."),
+        ],
+        output_hint="dict (result message) or None",
+    ),
+]
+
+
+def all_names() -> list[str]:
+    """Return every canonical name plus alias registered in ``REGISTRY``."""
+    names: list[str] = []
+    for spec in REGISTRY:
+        names.append(spec.name)
+        names.extend(spec.aliases)
+    return names

--- a/src/translator_component_toolkit/server.py
+++ b/src/translator_component_toolkit/server.py
@@ -3,258 +3,53 @@ Translator Component Toolkit MCP Server
 
 This server provides access to biomedical translator tools including:
 - Name resolution and lookup
-- Node normalization 
+- Node normalization
 - Knowledge provider information
 - Meta knowledge graph operations
 - Query orchestration
 - TRAPI protocol support
+
+Tools are generated from the schema-first registry in :mod:`schema`, so the MCP
+surface stays in lockstep with the library (and, later, the CLI).
 """
 
 from fastmcp import FastMCP
 from mcp.shared.exceptions import McpError
 from mcp.types import ErrorData, INTERNAL_ERROR
 
-# Import functions from translator_component_toolkit modules using relative imports
-from .name_resolver import lookup, synonyms, batch_lookup
-from .node_normalizer import get_normalized_nodes
-from .translator_kpinfo import get_translator_kp_info
-from .translator_metakg import get_KP_metadata, add_new_API_for_query, add_plover_API
-from .translator_query import get_translator_API_predicates, optimize_query_json, query_KP, parallel_api_query
-from .trapi import query as trapi_query
+from .schema import REGISTRY, ToolSpec, make_signed_callable
 
 # Create unified MCP server
 mcp = FastMCP("translator-toolkit")
 
-# Name Resolver Tools
-@mcp.tool()
-def name_lookup(query: str, return_top_response: bool = True, return_synonyms: bool = False):
-    """
-    Look up a name/term and return normalized TranslatorNode information.
-    
-    Args:
-        query: Query string to look up
-        return_top_response: If true, returns only the top response; if false, returns all responses
-        return_synonyms: If true, includes synonyms in the result
-        
-    Returns:
-        TranslatorNode object(s) with curie, label, types, and optional synonyms
-    """
-    try:
-        return lookup(query, return_top_response, return_synonyms)
-    except Exception as e:
-        raise McpError(ErrorData(INTERNAL_ERROR, f"Name lookup error: {str(e)}")) from e
 
-@mcp.tool()
-def get_name_synonyms(query: str):
-    """
-    Get synonyms for a given CURIE.
-    
-    Args:
-        query: Query CURIE to get synonyms for
-        
-    Returns:
-        Dictionary of CURIE id to TranslatorNode information
-    """
-    try:
-        return synonyms(query)
-    except Exception as e:
-        raise McpError(ErrorData(INTERNAL_ERROR, f"Synonyms lookup error: {str(e)}")) from e
+def _register(spec: ToolSpec) -> None:
+    """Register one tool (and its aliases) on the MCP server from a ToolSpec."""
+    base = make_signed_callable(spec)
 
-@mcp.tool()
-def batch_name_lookup(strings: list[str], size: int = 25, return_top_response: bool = True, return_synonyms: bool = False):
-    """
-    Batch lookup multiple names/terms and return normalized TranslatorNode information.
-    
-    Args:
-        strings: List of query strings to look up
-        size: Chunking size for batch processing (default: 25)
-        return_top_response: If true, returns only the top response per string
-        return_synonyms: If true, includes synonyms in the results
-        
-    Returns:
-        Dictionary mapping strings to their TranslatorNode information
-    """
-    try:
-        return batch_lookup(strings, size, return_top_response, return_synonyms)
-    except Exception as e:
-        raise McpError(ErrorData(INTERNAL_ERROR, f"Batch lookup error: {str(e)}")) from e
+    def wrap(name: str, description: str):
+        signed = make_signed_callable(spec)
 
-# Node Normalizer Tools
-@mcp.tool()
-def normalize_nodes(query: str, return_equivalent_identifiers: bool = False, conflate: bool = True, drug_chemical_conflate: bool = False):
-    """
-    Normalize node CURIEs using the Node Normalizer API.
-    
-    Args:
-        query: CURIE string or list of CURIEs to normalize
-        return_equivalent_identifiers: Whether to return equivalent identifiers
-        conflate: Enable gene-protein conflation (default: True)
-        drug_chemical_conflate: Enable drug-chemical conflation (default: False)
-        
-    Returns:
-        Normalized TranslatorNode(s) with curie, label, types, and optional synonyms
-    """
-    try:
-        return get_normalized_nodes(query, return_equivalent_identifiers, conflate=conflate, drug_chemical_conflate=drug_chemical_conflate)
-    except Exception as e:
-        raise McpError(ErrorData(INTERNAL_ERROR, f"Node normalization error: {str(e)}")) from e
+        def tool_fn(*args, **kwargs):
+            try:
+                return signed(*args, **kwargs)
+            except Exception as e:  # noqa: BLE001 - surfaced to MCP client
+                raise McpError(ErrorData(INTERNAL_ERROR, f"{name} error: {str(e)}")) from e
 
-# Knowledge Provider Info Tools
-@mcp.tool()
-def get_kp_info():
-    """
-    Get SmartAPI Translator Knowledge Provider information.
-    
-    Returns:
-        Tuple of (DataFrame with KP info, Dictionary mapping API names to URLs)
-    """
-    try:
-        return get_translator_kp_info()
-    except Exception as e:
-        raise McpError(ErrorData(INTERNAL_ERROR, f"KP info error: {str(e)}")) from e
+        tool_fn.__name__ = name
+        tool_fn.__qualname__ = name
+        tool_fn.__doc__ = description
+        tool_fn.__signature__ = signed.__signature__  # type: ignore[attr-defined]
+        tool_fn.__annotations__ = dict(signed.__annotations__)
+        mcp.tool(name=name, description=description)(tool_fn)
 
-# Meta Knowledge Graph Tools
-@mcp.tool()
-def get_metakg_data(api_names: dict):
-    """
-    Get metadata for Knowledge Providers including predicates, subjects, and objects.
-    
-    Args:
-        api_names: Dictionary mapping API names to URLs
-        
-    Returns:
-        DataFrame containing MetaKG information
-    """
-    try:
-        return get_KP_metadata(api_names)
-    except Exception as e:
-        raise McpError(ErrorData(INTERNAL_ERROR, f"MetaKG data error: {str(e)}")) from e
+    wrap(spec.name, spec.summary)
+    for alias in spec.aliases:
+        wrap(alias, f"Deprecated alias for `{spec.name}`. {spec.summary}")
 
-@mcp.tool()
-def add_custom_api_to_metakg(api_names: dict, metakg_df, new_api_name: str, new_api_url: str, 
-                             new_api_predicate: str, new_api_subject: str, new_api_object: str):
-    """
-    Add a custom API to the knowledge graph metadata.
-    
-    Args:
-        api_names: Current API names dictionary
-        metakg_df: Current MetaKG DataFrame
-        new_api_name: Name of the new API
-        new_api_url: URL of the new API
-        new_api_predicate: Predicate for the new API
-        new_api_subject: Subject type for the new API
-        new_api_object: Object type for the new API
-        
-    Returns:
-        Tuple of (updated api_names dict, updated metakg DataFrame)
-    """
-    try:
-        return add_new_API_for_query(api_names, metakg_df, new_api_name, new_api_url, 
-                                     new_api_predicate, new_api_subject, new_api_object)
-    except Exception as e:
-        raise McpError(ErrorData(INTERNAL_ERROR, f"Add custom API error: {str(e)}")) from e
+    # keep a module attribute so `from .server import name_lookup` still works
+    globals()[spec.name] = base
 
-@mcp.tool()
-def add_plover_apis_to_metakg(api_names: dict, metakg_df):
-    """
-    Add Plover APIs (CATRAX team APIs) to the knowledge graph metadata.
-    
-    Args:
-        api_names: Current API names dictionary
-        metakg_df: Current MetaKG DataFrame
-        
-    Returns:
-        Tuple of (updated api_names dict, updated metakg DataFrame)
-    """
-    try:
-        return add_plover_API(api_names, metakg_df)
-    except Exception as e:
-        raise McpError(ErrorData(INTERNAL_ERROR, f"Add Plover APIs error: {str(e)}")) from e
 
-# Query Tools
-@mcp.tool()
-def get_api_predicates():
-    """
-    Get the predicates supported by each Translator API.
-    
-    Returns:
-        Tuple of (API names dict, MetaKG DataFrame, API predicates dict)
-    """
-    try:
-        return get_translator_API_predicates()
-    except Exception as e:
-        raise McpError(ErrorData(INTERNAL_ERROR, f"API predicates error: {str(e)}")) from e
-
-@mcp.tool()
-def optimize_query_for_api(query_json: dict, api_name: str, api_predicates: dict):
-    """
-    Optimize a query JSON by removing predicates not supported by the selected API.
-    
-    Args:
-        query_json: TRAPI 1.5.0 format query
-        api_name: Name of the API to query
-        api_predicates: Dictionary of API names and their predicates
-        
-    Returns:
-        Modified query JSON with only supported predicates
-    """
-    try:
-        return optimize_query_json(query_json, api_name, api_predicates)
-    except Exception as e:
-        raise McpError(ErrorData(INTERNAL_ERROR, f"Query optimization error: {str(e)}")) from e
-
-@mcp.tool()
-def query_knowledge_provider(api_name: str, query_json: dict, api_names: dict, api_predicates: dict):
-    """
-    Query an individual Knowledge Provider API with a TRAPI 1.5.0 query.
-    
-    Args:
-        api_name: Name of the API to query
-        query_json: TRAPI 1.5.0 format query
-        api_names: Dictionary mapping API names to URLs
-        api_predicates: Dictionary of API names and their predicates
-        
-    Returns:
-        Query result from the API or None if no results
-    """
-    try:
-        return query_KP(api_name, query_json, api_names, api_predicates)
-    except Exception as e:
-        raise McpError(ErrorData(INTERNAL_ERROR, f"KP query error: {str(e)}")) from e
-
-@mcp.tool()
-def parallel_query_apis(query_json: dict, selected_apis: list[str], api_names: dict, api_predicates: dict, max_workers: int = 1):
-    """
-    Query multiple APIs in parallel and merge results into a single knowledge graph.
-    
-    Args:
-        query_json: TRAPI 1.5.0 format query
-        selected_apis: List of API names to query
-        api_names: Dictionary mapping API names to URLs
-        api_predicates: Dictionary of API names and their predicates
-        max_workers: Number of parallel workers (default: 1)
-        
-    Returns:
-        Merged knowledge graph from all successful API responses
-    """
-    try:
-        return parallel_api_query(query_json, selected_apis, api_names, api_predicates, max_workers)
-    except Exception as e:
-        raise McpError(ErrorData(INTERNAL_ERROR, f"Parallel query error: {str(e)}")) from e
-
-# TRAPI Tools
-@mcp.tool()
-def trapi_query_endpoint(url: str):
-    """
-    Query a TRAPI endpoint (currently unimplemented - placeholder).
-    
-    Args:
-        url: The URL for the TRAPI API endpoint
-        
-    Returns:
-        TODO: Implementation needed
-    """
-    try:
-        return trapi_query(url)
-    except Exception as e:
-        raise McpError(ErrorData(INTERNAL_ERROR, f"TRAPI query error: {str(e)}")) from e
+for _spec in REGISTRY:
+    _register(_spec)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,0 +1,86 @@
+"""Tests for the schema-first tool registry."""
+
+import inspect
+
+from translator_component_toolkit.schema import (
+    REGISTRY,
+    ParamSpec,
+    ToolSpec,
+    all_names,
+    make_signed_callable,
+)
+
+EXPECTED_NAMES = {
+    "name_lookup",
+    "get_name_synonyms",
+    "batch_name_lookup",
+    "normalize_nodes",
+    "get_kp_info",
+    "get_metakg_data",
+    "add_custom_api_to_metakg",
+    "add_plover_apis_to_metakg",
+    "get_api_predicates",
+    "optimize_query_for_api",
+    "query_knowledge_provider",
+    "parallel_query_apis",
+    "trapi_query_endpoint",
+}
+
+
+def test_registry_is_populated():
+    assert len(REGISTRY) >= 13
+    assert all(isinstance(spec, ToolSpec) for spec in REGISTRY)
+
+
+def test_registry_covers_expected_tools():
+    assert {spec.name for spec in REGISTRY} == EXPECTED_NAMES
+
+
+def test_names_are_unique_across_canonical_and_aliases():
+    names = all_names()
+    assert len(names) == len(set(names)), "duplicate tool name or alias detected"
+
+
+def test_every_func_is_callable():
+    for spec in REGISTRY:
+        assert callable(spec.func), f"{spec.name} func is not callable"
+
+
+def test_every_param_is_a_paramspec_with_help():
+    for spec in REGISTRY:
+        for p in spec.params:
+            assert isinstance(p, ParamSpec)
+            assert p.help, f"{spec.name}.{p.name} is missing help text"
+
+
+def test_summary_is_one_concise_line():
+    for spec in REGISTRY:
+        assert spec.summary
+        assert "\n" not in spec.summary
+
+
+def test_signed_callable_matches_paramspecs():
+    for spec in REGISTRY:
+        signed = make_signed_callable(spec)
+        sig = inspect.signature(signed)
+        assert list(sig.parameters) == [p.name for p in spec.params]
+        for p in spec.params:
+            param = sig.parameters[p.name]
+            if p.required:
+                assert param.default is inspect.Parameter.empty
+            else:
+                assert param.default == p.default
+
+
+def test_signed_callable_binds_and_delegates():
+    captured = {}
+
+    spec = ToolSpec(
+        name="demo",
+        summary="demo",
+        func=lambda a, b=2: captured.update(a=a, b=b),
+        params=[ParamSpec("a", int, required=True, help="a"), ParamSpec("b", int, default=2, help="b")],
+    )
+    signed = make_signed_callable(spec)
+    signed(1)
+    assert captured == {"a": 1, "b": 2}

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,6 +1,14 @@
 """Simple tests for TCT MCP Server functionality."""
 
+import asyncio
+
+from translator_component_toolkit.schema import all_names
 from translator_component_toolkit.server import mcp
+
+
+def _registered_tool_names():
+    tools = asyncio.run(mcp.list_tools())
+    return {t.name for t in tools}
 
 
 def test_mcp_server_exists():
@@ -11,15 +19,19 @@ def test_mcp_server_exists():
 
 def test_mcp_server_ready():
     """Test that MCP server is ready for orchestrating agent access."""
-    # Check that the server has the FastMCP functionality needed for agents
-    assert hasattr(mcp, 'run'), "MCP server should be runnable for agents"
+    assert hasattr(mcp, "run"), "MCP server should be runnable for agents"
     assert mcp.name == "translator-toolkit", "MCP server should have correct name for agents"
 
 
+def test_all_registry_tools_are_registered():
+    """Every canonical name and alias in the registry is exposed as an MCP tool."""
+    registered = _registered_tool_names()
+    assert set(all_names()).issubset(registered)
+
+
 def test_mcp_tools_accessible():
-    """Test that MCP tools are accessible to orchestrating agent."""
+    """Tool callables remain importable from the server module."""
     from translator_component_toolkit.server import name_lookup, normalize_nodes
-    
-    # These should exist as tool objects that agents can call
-    assert name_lookup is not None, "name_lookup tool should be accessible"
-    assert normalize_nodes is not None, "normalize_nodes tool should be accessible"
+
+    assert callable(name_lookup), "name_lookup tool should be accessible"
+    assert callable(normalize_nodes), "normalize_nodes tool should be accessible"


### PR DESCRIPTION
## Summary
- Add `schema.py`: a declarative `REGISTRY` of `ToolSpec`/`ParamSpec` describing all 13 agent-facing operations in one place.
- Generate MCP tools from the registry (`server.py`) instead of 13 hand-written wrappers, so MCP, library, and the future CLI stay in lockstep.
- Fix the broken `trapi_query_endpoint` placeholder to match `trapi.query(url, query)`.

## Notes
- Behavior is unchanged; tool names are identical to before (canonical-vocab rename is the next PR in the stack).
- First PR in the stack; base `main`.

## Test plan
- [x] `uv run pytest` (56 passed, 1 skipped)
- [x] `uv run ruff check` on changed files
- [x] MCP smoke: all 13 registry tools registered (`tests/test_server.py`)

Closes #4