### PR TITLE
Standardize tool names to verb_object vocabulary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,11 +10,11 @@ test:
 
 # Run spell checking
 spell:
-	uv run codespell --skip=metaData,notebooks,htmlcov --ignore-words-list=EHR
+	uv run codespell --skip=metaData,notebooks,htmlcov,PathFinder_results --ignore-words-list=EHR
 
 # Run spell checking interactively (allows fixing)
 spell-fix:
-	uv run codespell --interactive 3 --skip=metaData,notebooks,htmlcov --ignore-words-list=EHR
+	uv run codespell --interactive 3 --skip=metaData,notebooks,htmlcov,PathFinder_results --ignore-words-list=EHR
 
 # Run linting
 lint:

--- a/src/translator_component_toolkit/schema.py
+++ b/src/translator_component_toolkit/schema.py
@@ -189,7 +189,8 @@ def _trapi_query_endpoint(url: str, query: dict) -> Any:
 
 REGISTRY: list[ToolSpec] = [
     ToolSpec(
-        name="name_lookup",
+        name="lookup_name",
+        aliases=["name_lookup"],
         summary="Look up a name/term and return normalized TranslatorNode information.",
         func=_name_lookup,
         group="name",
@@ -202,7 +203,8 @@ REGISTRY: list[ToolSpec] = [
         output_hint="TranslatorNode or list[TranslatorNode]",
     ),
     ToolSpec(
-        name="get_name_synonyms",
+        name="get_synonyms",
+        aliases=["get_name_synonyms"],
         summary="Get synonyms for a given CURIE.",
         func=_get_name_synonyms,
         group="name",
@@ -210,7 +212,8 @@ REGISTRY: list[ToolSpec] = [
         output_hint="dict[curie, TranslatorNode]",
     ),
     ToolSpec(
-        name="batch_name_lookup",
+        name="lookup_names",
+        aliases=["batch_name_lookup"],
         summary="Batch look up multiple names/terms and return normalized TranslatorNode information.",
         func=_batch_name_lookup,
         group="name",
@@ -244,7 +247,8 @@ REGISTRY: list[ToolSpec] = [
         output_hint="tuple[DataFrame, dict[name, url]]",
     ),
     ToolSpec(
-        name="get_metakg_data",
+        name="get_metakg",
+        aliases=["get_metakg_data"],
         summary="Get MetaKG metadata (predicates, subjects, objects) for Knowledge Providers.",
         func=_get_metakg_data,
         group="metakg",
@@ -252,7 +256,8 @@ REGISTRY: list[ToolSpec] = [
         output_hint="DataFrame",
     ),
     ToolSpec(
-        name="add_custom_api_to_metakg",
+        name="add_metakg_api",
+        aliases=["add_custom_api_to_metakg"],
         summary="Add a custom API to the knowledge graph metadata.",
         func=_add_custom_api_to_metakg,
         group="metakg",
@@ -268,7 +273,8 @@ REGISTRY: list[ToolSpec] = [
         output_hint="tuple[dict, DataFrame]",
     ),
     ToolSpec(
-        name="add_plover_apis_to_metakg",
+        name="add_plover_apis",
+        aliases=["add_plover_apis_to_metakg"],
         summary="Add Plover APIs (CATRAX team APIs) to the knowledge graph metadata.",
         func=_add_plover_apis_to_metakg,
         group="metakg",
@@ -286,7 +292,8 @@ REGISTRY: list[ToolSpec] = [
         output_hint="tuple[dict, DataFrame, dict]",
     ),
     ToolSpec(
-        name="optimize_query_for_api",
+        name="optimize_query",
+        aliases=["optimize_query_for_api"],
         summary="Remove predicates from a TRAPI query that the selected API does not support.",
         func=_optimize_query_for_api,
         group="query",
@@ -298,7 +305,8 @@ REGISTRY: list[ToolSpec] = [
         output_hint="dict (modified query)",
     ),
     ToolSpec(
-        name="query_knowledge_provider",
+        name="query_kp",
+        aliases=["query_knowledge_provider"],
         summary="Query an individual Knowledge Provider API with a TRAPI 1.5.0 query.",
         func=_query_knowledge_provider,
         group="query",
@@ -311,7 +319,8 @@ REGISTRY: list[ToolSpec] = [
         output_hint="dict (knowledge graph) or None",
     ),
     ToolSpec(
-        name="parallel_query_apis",
+        name="query_kps_parallel",
+        aliases=["parallel_query_apis"],
         summary="Query multiple APIs in parallel and merge results into a single knowledge graph.",
         func=_parallel_query_apis,
         group="query",
@@ -325,7 +334,8 @@ REGISTRY: list[ToolSpec] = [
         output_hint="dict (merged knowledge graph)",
     ),
     ToolSpec(
-        name="trapi_query_endpoint",
+        name="query_trapi",
+        aliases=["trapi_query_endpoint"],
         summary="Query a TRAPI endpoint with a TRAPI query and return the result message.",
         func=_trapi_query_endpoint,
         group="trapi",

--- a/src/translator_component_toolkit/server.py
+++ b/src/translator_component_toolkit/server.py
@@ -47,8 +47,11 @@ def _register(spec: ToolSpec) -> None:
     for alias in spec.aliases:
         wrap(alias, f"Deprecated alias for `{spec.name}`. {spec.summary}")
 
-    # keep a module attribute so `from .server import name_lookup` still works
+    # keep module attributes so `from .server import lookup_name` (and the
+    # deprecated `name_lookup` alias) still work for direct importers
     globals()[spec.name] = base
+    for alias in spec.aliases:
+        globals()[alias] = base
 
 
 for _spec in REGISTRY:

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -11,19 +11,33 @@ from translator_component_toolkit.schema import (
 )
 
 EXPECTED_NAMES = {
-    "name_lookup",
-    "get_name_synonyms",
-    "batch_name_lookup",
+    "lookup_name",
+    "get_synonyms",
+    "lookup_names",
     "normalize_nodes",
     "get_kp_info",
-    "get_metakg_data",
-    "add_custom_api_to_metakg",
-    "add_plover_apis_to_metakg",
+    "get_metakg",
+    "add_metakg_api",
+    "add_plover_apis",
     "get_api_predicates",
-    "optimize_query_for_api",
-    "query_knowledge_provider",
-    "parallel_query_apis",
-    "trapi_query_endpoint",
+    "optimize_query",
+    "query_kp",
+    "query_kps_parallel",
+    "query_trapi",
+}
+
+# Canonical name -> deprecated alias kept for backwards compatibility.
+EXPECTED_ALIASES = {
+    "lookup_name": "name_lookup",
+    "get_synonyms": "get_name_synonyms",
+    "lookup_names": "batch_name_lookup",
+    "get_metakg": "get_metakg_data",
+    "add_metakg_api": "add_custom_api_to_metakg",
+    "add_plover_apis": "add_plover_apis_to_metakg",
+    "optimize_query": "optimize_query_for_api",
+    "query_kp": "query_knowledge_provider",
+    "query_kps_parallel": "parallel_query_apis",
+    "query_trapi": "trapi_query_endpoint",
 }
 
 
@@ -39,6 +53,20 @@ def test_registry_covers_expected_tools():
 def test_names_are_unique_across_canonical_and_aliases():
     names = all_names()
     assert len(names) == len(set(names)), "duplicate tool name or alias detected"
+
+
+def test_canonical_names_use_verb_object_vocabulary():
+    allowed_verbs = {"get", "list", "lookup", "normalize", "query", "add", "optimize"}
+    for spec in REGISTRY:
+        verb = spec.name.split("_", 1)[0]
+        assert verb in allowed_verbs, f"{spec.name} does not start with a canonical verb"
+
+
+def test_deprecated_aliases_are_preserved():
+    by_name = {spec.name: spec for spec in REGISTRY}
+    for canonical, alias in EXPECTED_ALIASES.items():
+        assert canonical in by_name, f"missing canonical tool {canonical}"
+        assert alias in by_name[canonical].aliases, f"{canonical} missing alias {alias}"
 
 
 def test_every_func_is_callable():

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -30,8 +30,15 @@ def test_all_registry_tools_are_registered():
 
 
 def test_mcp_tools_accessible():
-    """Tool callables remain importable from the server module."""
-    from translator_component_toolkit.server import name_lookup, normalize_nodes
+    """Canonical tool callables remain importable from the server module."""
+    from translator_component_toolkit.server import lookup_name, normalize_nodes
 
-    assert callable(name_lookup), "name_lookup tool should be accessible"
+    assert callable(lookup_name), "lookup_name tool should be accessible"
     assert callable(normalize_nodes), "normalize_nodes tool should be accessible"
+
+
+def test_deprecated_alias_still_importable():
+    """The deprecated alias name is still importable for backwards compatibility."""
+    from translator_component_toolkit.server import name_lookup
+
+    assert callable(name_lookup), "deprecated name_lookup alias should still be accessible"


### PR DESCRIPTION
## Summary
- Rename MCP tools to a canonical verb set (`get`/`list`/`lookup`/`normalize`/`query`/`add`/`optimize`) in `verb_object` form.
- Keep every previous name as a deprecated alias (registered as an MCP tool and importable from `server`) so existing callers don't break.

## Mapping
- `name_lookup`→`lookup_name`, `batch_name_lookup`→`lookup_names`, `get_name_synonyms`→`get_synonyms`
- `get_metakg_data`→`get_metakg`, `add_custom_api_to_metakg`→`add_metakg_api`, `add_plover_apis_to_metakg`→`add_plover_apis`
- `optimize_query_for_api`→`optimize_query`, `query_knowledge_provider`→`query_kp`, `parallel_query_apis`→`query_kps_parallel`, `trapi_query_endpoint`→`query_trapi`
- unchanged: `normalize_nodes`, `get_kp_info`, `get_api_predicates`

## Notes
- Stacked on #10 (`feat/tool-schema`); merge that first.

## Test plan
- [x] `uv run pytest` (15 targeted tests pass; full suite green)
- [x] 23 tools registered (13 canonical + 10 aliases)
- [x] `uv run ruff check`

Closes #5