### PR TITLE
Map exceptions to teaching MCP errors

### DIFF
--- a/src/translator_component_toolkit/errors.py
+++ b/src/translator_component_toolkit/errors.py
@@ -1,0 +1,59 @@
+"""
+Error mapping for agent-facing surfaces.
+
+The MCP server previously collapsed every exception into ``INTERNAL_ERROR``,
+which hides the real cause and offers no guidance. This module maps Python
+exception types to appropriate MCP error codes and produces messages that
+*teach* (e.g. enumerating valid values) so an agent can correct its call.
+"""
+
+from __future__ import annotations
+
+import requests
+from mcp.shared.exceptions import McpError
+from mcp.types import INTERNAL_ERROR, INVALID_PARAMS, ErrorData
+
+# Cap enumerated choices so a teaching message stays bounded.
+MAX_LISTED_CHOICES = 20
+
+
+class InvalidParameterError(ValueError):
+    """Raised for invalid user input; maps to MCP ``INVALID_PARAMS``."""
+
+
+def format_choices(valid: list[str], limit: int = MAX_LISTED_CHOICES) -> str:
+    """Render a bounded, comma-separated list of valid values."""
+    listed = list(valid)
+    head = listed[:limit]
+    suffix = "" if len(listed) <= limit else f", ... (+{len(listed) - limit} more)"
+    return ", ".join(repr(v) for v in head) + suffix
+
+
+def validate_choice(value: str, valid, param_name: str) -> None:
+    """Raise :class:`InvalidParameterError` enumerating valid values on mismatch."""
+    valid_list = list(valid)
+    if value not in valid_list:
+        raise InvalidParameterError(
+            f"{param_name} {value!r} is not valid. Must be one of: {format_choices(valid_list)}"
+        )
+
+
+def to_mcp_error(exc: Exception, tool_name: str) -> McpError:
+    """Map a raised exception to an :class:`McpError` with a teaching message.
+
+    - ``InvalidParameterError`` / ``LookupError`` -> ``INVALID_PARAMS``
+    - ``requests.RequestException`` -> ``INTERNAL_ERROR`` (upstream/API failure)
+    - anything else -> ``INTERNAL_ERROR``
+    """
+    if isinstance(exc, (InvalidParameterError, LookupError)):
+        return McpError(ErrorData(code=INVALID_PARAMS, message=f"{tool_name}: {exc}"))
+
+    if isinstance(exc, requests.RequestException):
+        status = None
+        response = getattr(exc, "response", None)
+        if response is not None:
+            status = getattr(response, "status_code", None)
+        detail = f" (HTTP {status})" if status is not None else ""
+        return McpError(ErrorData(code=INTERNAL_ERROR, message=f"{tool_name}: upstream API error{detail}: {exc}"))
+
+    return McpError(ErrorData(code=INTERNAL_ERROR, message=f"{tool_name}: {exc}"))

--- a/src/translator_component_toolkit/schema.py
+++ b/src/translator_component_toolkit/schema.py
@@ -20,6 +20,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from . import name_resolver, node_normalizer, translator_kpinfo, translator_metakg, translator_query, trapi
+from .errors import validate_choice
 
 
 @dataclass(frozen=True)
@@ -167,10 +168,12 @@ def _get_api_predicates() -> Any:
 
 
 def _optimize_query_for_api(query_json: dict, api_name: str, api_predicates: dict) -> Any:
+    validate_choice(api_name, api_predicates.keys(), "api_name")
     return translator_query.optimize_query_json(query_json, api_name, api_predicates)
 
 
 def _query_knowledge_provider(api_name: str, query_json: dict, api_names: dict, api_predicates: dict) -> Any:
+    validate_choice(api_name, api_names.keys(), "api_name")
     return translator_query.query_KP(api_name, query_json, api_names, api_predicates)
 
 

--- a/src/translator_component_toolkit/server.py
+++ b/src/translator_component_toolkit/server.py
@@ -14,9 +14,8 @@ surface stays in lockstep with the library (and, later, the CLI).
 """
 
 from fastmcp import FastMCP
-from mcp.shared.exceptions import McpError
-from mcp.types import ErrorData, INTERNAL_ERROR
 
+from .errors import to_mcp_error
 from .schema import REGISTRY, ToolSpec, make_signed_callable
 
 # Create unified MCP server
@@ -33,8 +32,8 @@ def _register(spec: ToolSpec) -> None:
         def tool_fn(*args, **kwargs):
             try:
                 return signed(*args, **kwargs)
-            except Exception as e:  # noqa: BLE001 - surfaced to MCP client
-                raise McpError(ErrorData(INTERNAL_ERROR, f"{name} error: {str(e)}")) from e
+            except Exception as e:  # noqa: BLE001 - mapped to a teaching McpError
+                raise to_mcp_error(e, name) from e
 
         tool_fn.__name__ = name
         tool_fn.__qualname__ = name

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,0 +1,66 @@
+"""Tests for teaching error mapping."""
+
+import pytest
+import requests
+from mcp.shared.exceptions import McpError
+from mcp.types import INTERNAL_ERROR, INVALID_PARAMS
+
+from translator_component_toolkit.errors import (
+    InvalidParameterError,
+    format_choices,
+    to_mcp_error,
+    validate_choice,
+)
+
+
+def test_validate_choice_passes_for_valid_value():
+    validate_choice("a", ["a", "b"], "param")  # should not raise
+
+
+def test_validate_choice_enumerates_valid_values():
+    with pytest.raises(InvalidParameterError) as exc:
+        validate_choice("z", ["a", "b"], "api_name")
+    msg = str(exc.value)
+    assert "api_name" in msg
+    assert "'a'" in msg and "'b'" in msg
+
+
+def test_format_choices_is_bounded():
+    rendered = format_choices([str(i) for i in range(50)], limit=20)
+    assert "+30 more" in rendered
+
+
+def test_invalid_parameter_error_maps_to_invalid_params():
+    err = to_mcp_error(InvalidParameterError("bad"), "query_kp")
+    assert isinstance(err, McpError)
+    assert err.error.code == INVALID_PARAMS
+    assert "query_kp" in err.error.message
+
+
+def test_lookup_error_maps_to_invalid_params():
+    err = to_mcp_error(LookupError("no match for 'AML'"), "lookup_name")
+    assert err.error.code == INVALID_PARAMS
+    assert "no match" in err.error.message
+
+
+def test_request_exception_maps_to_internal_error_with_status():
+    response = requests.Response()
+    response.status_code = 503
+    exc = requests.HTTPError("service unavailable")
+    exc.response = response
+    err = to_mcp_error(exc, "get_kp_info")
+    assert err.error.code == INTERNAL_ERROR
+    assert "HTTP 503" in err.error.message
+
+
+def test_unknown_exception_maps_to_internal_error():
+    err = to_mcp_error(RuntimeError("boom"), "normalize_nodes")
+    assert err.error.code == INTERNAL_ERROR
+    assert "boom" in err.error.message
+
+
+def test_query_kp_adapter_validates_api_name():
+    from translator_component_toolkit.schema import _query_knowledge_provider
+
+    with pytest.raises(InvalidParameterError):
+        _query_knowledge_provider("UnknownAPI", {}, {"Real API": "http://x"}, {})


### PR DESCRIPTION
## Summary
- Add `errors.py` with `to_mcp_error(exc, tool_name)` mapping: invalid input / `LookupError` -> `INVALID_PARAMS`; `requests.RequestException` -> `INTERNAL_ERROR` with HTTP status; everything else -> `INTERNAL_ERROR`.
- `validate_choice()` raises an enumerating "must be one of: ..." message (bounded to 20 values).
- Wrap tool calls once in the server factory instead of 13 per-tool try/excepts; validate `api_name` in the query adapters.
- Fix latent positional `ErrorData(...)` construction (pydantic requires keyword args).

## Notes
- Stacked on #11 (`feat/canonical-vocab`); merge that first.

## Test plan
- [x] `uv run pytest` (67 passed, 1 skipped)
- [x] `tests/test_errors.py` covers each mapping + adapter validation
- [x] `uv run ruff check`

Closes #6