### PR TITLE
Resurrect CLI as a thin mirror of the MCP registry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ Issues = "https://github.com/NCATSTranslator/Translator_component_toolkit/issues
 [project.scripts]
 mcp-translator = "translator_component_toolkit.__main__:main"
 tct-server = "main:main"
+tct = "translator_component_toolkit.cli:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/src/translator_component_toolkit/cli.py
+++ b/src/translator_component_toolkit/cli.py
@@ -1,0 +1,140 @@
+"""
+Command-line interface for the Translator Component Toolkit.
+
+The CLI is generated from the schema-first :data:`schema.REGISTRY`, so it
+mirrors the MCP tool surface by construction: every tool becomes a subcommand
+under a group derived from ``ToolSpec.group``. Scalar required parameters are
+positional arguments; optional parameters are options; complex parameters
+(dicts/lists) are passed as JSON strings.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+import click
+
+from .schema import REGISTRY, ParamSpec, ToolSpec, make_signed_callable
+
+
+def _is_option(p: ParamSpec) -> bool:
+    """Optional params and booleans become Click options; required scalars are arguments."""
+    return p.type is bool or not p.required
+
+
+def _is_json_param(p: ParamSpec) -> bool:
+    """True if the parameter should be supplied as a JSON string on the CLI."""
+    return p.type not in (str, int, float, bool)
+
+
+def _dest(p: ParamSpec) -> str:
+    return "param_" + p.name if _is_option(p) else p.name
+
+
+def _json_callback(ctx, param, value):
+    if value is None:
+        return None
+    try:
+        return json.loads(value)
+    except json.JSONDecodeError as e:
+        raise click.BadParameter(f"{param.name} must be valid JSON: {e}") from e
+
+
+def _echo_result(result: Any) -> None:
+    """Best-effort rendering of a tool result as JSON (refined in a later PR)."""
+    try:
+        click.echo(json.dumps(result, indent=2, default=str))
+    except TypeError:
+        click.echo(str(result))
+
+
+def _build_command(spec: ToolSpec) -> click.Command:
+    callable_ = make_signed_callable(spec)
+    decorators = []
+
+    for p in spec.params:
+        flag = p.name.replace("_", "-")
+        if p.type is bool:
+            decorators.append(
+                click.option(f"--{flag}/--no-{flag}", _dest(p), default=p.default, help=p.help)
+            )
+        elif _is_json_param(p):
+            if p.required:
+                decorators.append(click.argument(p.name, callback=_json_callback))
+            else:
+                decorators.append(
+                    click.option(f"--{flag}", _dest(p), callback=_json_callback, default=None, help=p.help)
+                )
+        else:
+            click_type = {int: int, float: float}.get(p.type, str)
+            if p.required:
+                decorators.append(click.argument(p.name, type=click_type))
+            else:
+                decorators.append(
+                    click.option(f"--{flag}", _dest(p), type=click_type, default=p.default, help=p.help)
+                )
+
+    def callback(**kwargs):
+        # Map click destinations back to the spec parameter names.
+        call_kwargs = {p.name: kwargs.get(_dest(p)) for p in spec.params}
+        try:
+            result = callable_(**call_kwargs)
+        except Exception as e:  # noqa: BLE001 - surfaced to the user
+            click.echo(f"Error: {e}", err=True)
+            sys.exit(1)
+        _echo_result(result)
+
+    command_name = spec.name.replace("_", "-")
+    cmd = click.command(name=command_name, help=spec.summary)(callback)
+    for decorator in reversed(decorators):
+        cmd = decorator(cmd)
+    return cmd
+
+
+@click.group()
+@click.version_option()
+def main():
+    """Translator Component Toolkit - biomedical knowledge graph tools."""
+
+
+# Build one group per ToolSpec.group and attach generated commands.
+_GROUP_HELP = {
+    "name": "Name resolution and lookup commands.",
+    "normalize": "Node normalization commands.",
+    "kp": "Knowledge Provider information commands.",
+    "metakg": "Meta knowledge graph commands.",
+    "query": "Query orchestration commands.",
+    "trapi": "TRAPI protocol commands.",
+}
+
+_groups: dict[str, click.Group] = {}
+for _spec in REGISTRY:
+    if _spec.group not in _groups:
+        grp = click.Group(name=_spec.group, help=_GROUP_HELP.get(_spec.group, f"{_spec.group} commands."))
+        _groups[_spec.group] = grp
+        main.add_command(grp)
+    _groups[_spec.group].add_command(_build_command(_spec))
+
+
+@main.group()
+def server():
+    """MCP server commands."""
+
+
+@server.command()
+@click.option("--transport", type=click.Choice(["stdio", "http"]), default="stdio")
+@click.option("--port", default=8000, help="Port for HTTP transport.")
+def start(transport: str, port: int):
+    """Start the MCP server."""
+    from .server import mcp
+
+    if transport == "http":
+        mcp.run(transport="http", port=port)
+    else:
+        mcp.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,52 @@
+"""Tests for the registry-generated CLI."""
+
+from click.testing import CliRunner
+
+from translator_component_toolkit.cli import main
+from translator_component_toolkit.schema import REGISTRY
+
+
+def test_cli_help():
+    runner = CliRunner()
+    result = runner.invoke(main, ["--help"])
+    assert result.exit_code == 0
+    assert "Translator Component Toolkit" in result.output
+
+
+def test_expected_groups_exist():
+    runner = CliRunner()
+    for group in ["name", "normalize", "kp", "metakg", "query", "trapi", "server"]:
+        result = runner.invoke(main, [group, "--help"])
+        assert result.exit_code == 0, f"group {group} missing"
+
+
+def test_every_registry_tool_has_a_command():
+    runner = CliRunner()
+    for spec in REGISTRY:
+        command_name = spec.name.replace("_", "-")
+        result = runner.invoke(main, [spec.group, command_name, "--help"])
+        assert result.exit_code == 0, f"missing command {spec.group} {command_name}"
+        assert command_name in result.output
+        assert spec.summary.split()[0] in result.output
+
+
+def test_server_start_command_exists():
+    runner = CliRunner()
+    result = runner.invoke(main, ["server", "start", "--help"])
+    assert result.exit_code == 0
+    assert "Start the MCP server" in result.output
+
+
+def test_required_argument_is_enforced():
+    runner = CliRunner()
+    # lookup-name requires a query argument
+    result = runner.invoke(main, ["name", "lookup-name"])
+    assert result.exit_code != 0
+
+
+def test_invalid_json_argument_is_rejected():
+    runner = CliRunner()
+    # get-metakg takes a JSON dict argument; pass invalid JSON
+    result = runner.invoke(main, ["metakg", "get-metakg", "{not json"])
+    assert result.exit_code != 0
+    assert "valid JSON" in result.output


### PR DESCRIPTION
## Summary
- Adds `src/translator_component_toolkit/cli.py`, a Click CLI generated from `schema.REGISTRY` so the CLI mirrors the MCP tool surface by construction.
- One command group per `ToolSpec.group` (`name`, `normalize`, `kp`, `metakg`, `query`, `trapi`) plus a `server start` subcommand (stdio/http).
- Registers the `tct` console script in `pyproject.toml`.

## Mapping rules
- Required scalar params → positional arguments.
- Optional/bool params → options (`--flag/--no-flag` for bools).
- Complex params (dict/list) → JSON string arguments/options with validation.

## Test plan
- [x] `tct --help` and every group `--help`
- [x] Every registry tool has a matching command
- [x] `server start --help` exists
- [x] Required argument enforced; invalid JSON rejected
- [x] Full suite green (73 passed, 1 skipped), ruff clean

Closes #7