### PR TITLE
Add output contract: serializer, --json, stdout/stderr split, exit codes

### DIFF
--- a/src/translator_component_toolkit/cli.py
+++ b/src/translator_component_toolkit/cli.py
@@ -15,7 +15,16 @@ import sys
 from typing import Any
 
 import click
+import requests
 
+from .errors import InvalidParameterError
+from .io import (
+    EXIT_NOT_FOUND,
+    EXIT_UNEXPECTED,
+    EXIT_UPSTREAM,
+    EXIT_USAGE,
+    serialize,
+)
 from .schema import REGISTRY, ParamSpec, ToolSpec, make_signed_callable
 
 
@@ -42,12 +51,19 @@ def _json_callback(ctx, param, value):
         raise click.BadParameter(f"{param.name} must be valid JSON: {e}") from e
 
 
-def _echo_result(result: Any) -> None:
-    """Best-effort rendering of a tool result as JSON (refined in a later PR)."""
-    try:
-        click.echo(json.dumps(result, indent=2, default=str))
-    except TypeError:
-        click.echo(str(result))
+def _echo_result(result: Any, as_json: bool) -> None:
+    """Write a normalized tool result to stdout.
+
+    ``serialize`` flattens dataclasses/DataFrames/tuples into JSON-safe
+    primitives. With ``--json`` (the default) the result is emitted as JSON;
+    with ``--no-json`` the serialized structure is printed in its Python repr
+    for quick human scanning.
+    """
+    normalized = serialize(result)
+    if as_json:
+        click.echo(json.dumps(normalized, indent=2, default=str))
+    else:
+        click.echo(str(normalized))
 
 
 def _build_command(spec: ToolSpec) -> click.Command:
@@ -76,15 +92,26 @@ def _build_command(spec: ToolSpec) -> click.Command:
                     click.option(f"--{flag}", _dest(p), type=click_type, default=p.default, help=p.help)
                 )
 
-    def callback(**kwargs):
+    @click.pass_context
+    def callback(ctx, **kwargs):
         # Map click destinations back to the spec parameter names.
         call_kwargs = {p.name: kwargs.get(_dest(p)) for p in spec.params}
+        as_json = ctx.obj.get("json", True) if ctx.obj else True
         try:
             result = callable_(**call_kwargs)
+        except InvalidParameterError as e:
+            click.echo(f"Error: {e}", err=True)
+            sys.exit(EXIT_USAGE)
+        except LookupError as e:
+            click.echo(f"Error: {e}", err=True)
+            sys.exit(EXIT_NOT_FOUND)
+        except requests.RequestException as e:
+            click.echo(f"Error: upstream request failed: {e}", err=True)
+            sys.exit(EXIT_UPSTREAM)
         except Exception as e:  # noqa: BLE001 - surfaced to the user
             click.echo(f"Error: {e}", err=True)
-            sys.exit(1)
-        _echo_result(result)
+            sys.exit(EXIT_UNEXPECTED)
+        _echo_result(result, as_json)
 
     command_name = spec.name.replace("_", "-")
     cmd = click.command(name=command_name, help=spec.summary)(callback)
@@ -95,8 +122,17 @@ def _build_command(spec: ToolSpec) -> click.Command:
 
 @click.group()
 @click.version_option()
-def main():
-    """Translator Component Toolkit - biomedical knowledge graph tools."""
+@click.option("--json/--no-json", "as_json", default=True,
+              help="Emit machine-readable JSON to stdout (default) or a plain repr.")
+@click.pass_context
+def main(ctx, as_json: bool):
+    """Translator Component Toolkit - biomedical knowledge graph tools.
+
+    Data is written to stdout; diagnostics go to stderr. Exit codes: 0 success,
+    2 usage/invalid parameter, 3 not found, 4 upstream API error, 1 unexpected.
+    """
+    ctx.ensure_object(dict)
+    ctx.obj["json"] = as_json
 
 
 # Build one group per ToolSpec.group and attach generated commands.

--- a/src/translator_component_toolkit/io.py
+++ b/src/translator_component_toolkit/io.py
@@ -1,0 +1,56 @@
+"""
+Output serialization for agent-facing surfaces.
+
+Tool results are a mix of dataclasses (``TranslatorNode``), pandas
+``DataFrame``s, tuples, dicts, and lists. :func:`serialize` normalizes any of
+these into JSON-safe Python primitives so the CLI (and other callers) can emit
+a single, predictable shape regardless of which library function produced it.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import Any
+
+# Exit codes for the CLI output contract. Documented here so the CLI and its
+# tests share one source of truth.
+EXIT_OK = 0
+EXIT_USAGE = 2
+EXIT_NOT_FOUND = 3
+EXIT_UPSTREAM = 4
+EXIT_UNEXPECTED = 1
+
+
+def _is_dataframe(obj: Any) -> bool:
+    """True if ``obj`` is a pandas DataFrame, without importing pandas eagerly."""
+    cls = type(obj)
+    return cls.__module__.startswith("pandas") and cls.__name__ == "DataFrame"
+
+
+def serialize(obj: Any) -> Any:
+    """Recursively convert ``obj`` into JSON-safe primitives.
+
+    - dataclass instances -> ``dataclasses.asdict`` (recursively serialized)
+    - pandas ``DataFrame`` -> list of record dicts
+    - tuples -> lists
+    - dicts -> dicts with serialized values (keys coerced to ``str``)
+    - lists/sets -> lists of serialized items
+    - primitives (``str``/``int``/``float``/``bool``/``None``) -> unchanged
+    - anything else -> ``str(obj)`` as a last resort
+    """
+    if obj is None or isinstance(obj, (str, int, float, bool)):
+        return obj
+
+    if dataclasses.is_dataclass(obj) and not isinstance(obj, type):
+        return {k: serialize(v) for k, v in dataclasses.asdict(obj).items()}
+
+    if _is_dataframe(obj):
+        return obj.to_dict(orient="records")
+
+    if isinstance(obj, dict):
+        return {str(k): serialize(v) for k, v in obj.items()}
+
+    if isinstance(obj, (list, tuple, set)):
+        return [serialize(v) for v in obj]
+
+    return str(obj)

--- a/src/translator_component_toolkit/node_normalizer.py
+++ b/src/translator_component_toolkit/node_normalizer.py
@@ -3,11 +3,14 @@ This is a wrapper around the Node Normalizer API.
 
 API docs: https://nodenorm.transltr.io/docs
 """
+import logging
 import urllib.parse
 
 import requests
 
 from .translator_node import TranslatorNode
+
+logger = logging.getLogger(__name__)
 
 
 URL = 'https://nodenorm.ci.transltr.io/'
@@ -125,11 +128,11 @@ def get_preferred_names(id_list:list[str], batch_limit=500, **kwargs) -> dict[st
             else:
                 label = normalized_nodes[curie].label
                 if label is None:
-                    print(curie + ": no preferred name")
+                    logger.debug("%s: no preferred name", curie)
                     label = curie
                 name_map[curie] = label
     if len(unmapped_ids) > 0:
-        print("NodeNorm does not know about these identifiers: " + ",".join(unmapped_ids))
+        logger.info("NodeNorm does not know about these identifiers: %s", ",".join(unmapped_ids))
     return name_map
 
 
@@ -181,13 +184,13 @@ def ID_convert_to_preferred_name_nodeNormalizer(id_list):
                 label = identifier.get('label')
                 dic_id_map[curie] = label
                 if not label:
-                    print(curie + ": no preferred name")
+                    logger.debug("%s: no preferred name", curie)
                     dic_id_map[curie] = curie
             else:
                 unrecoglized_ids.append(curie)
 
                 dic_id_map[curie] = curie
     if len(unrecoglized_ids) > 0:
-        print("NodeNorm does not know about these identifiers: " + ",".join(unrecoglized_ids))
+        logger.info("NodeNorm does not know about these identifiers: %s", ",".join(unrecoglized_ids))
 
     return dic_id_map

--- a/src/translator_component_toolkit/translator_kpinfo.py
+++ b/src/translator_component_toolkit/translator_kpinfo.py
@@ -1,9 +1,13 @@
 
 # used May 30, 2025
 
+import logging
+
 import requests
 import json
 import pandas as pd
+
+logger = logging.getLogger(__name__)
 
 """This is the root URL for the resource."""
 URL = 'https://smart-api.info/api/query?q=tags.name:translator'
@@ -32,9 +36,11 @@ def get_translator_kp_info() -> tuple[pd.DataFrame, dict[str, str]]:
     response = requests.get(url)
     try:
         response.raise_for_status()
-    except Exception:
-        print(f"error downloading smartapi specs: {response.status_code}")
-        exit()
+    except requests.RequestException as e:
+        logger.error("error downloading smartapi specs: %s", response.status_code)
+        raise requests.RequestException(
+            f"error downloading smartapi specs: {response.status_code}"
+        ) from e
 
     content = json.loads(response.content)
     smartapis = content["hits"]
@@ -54,8 +60,8 @@ def get_translator_kp_info() -> tuple[pd.DataFrame, dict[str, str]]:
             
             server = api['servers'][i]
             if 'x-maturity' not in server:
-                print(f"Skipping server without x-maturity: {server}")
-                
+                logger.debug("Skipping server without x-maturity: %s", server)
+
             else:
                 if server['x-maturity'] == 'production':
                     # if prod_ur is not ars-prod.transltr.io
@@ -99,8 +105,8 @@ def get_translator_kp_info() -> tuple[pd.DataFrame, dict[str, str]]:
                     test_found = True
 
         if not (prod_found or ci_found or test_found):
-            print(api['info']['title'])
-            print(f"Skipping server without production, staging or testing: {server}")
+            logger.debug("%s", api['info']['title'])
+            logger.debug("Skipping server without production, staging or testing: %s", server)
         else:
             id_list.append('https://smart-api.info/ui/'+api['_id'])
             title_list.append(api['info']['title'])

--- a/src/translator_component_toolkit/translator_metakg.py
+++ b/src/translator_component_toolkit/translator_metakg.py
@@ -1,6 +1,10 @@
+import logging
+
 import requests
 import json
 import pandas as pd
+
+logger = logging.getLogger(__name__)
 
 
 def find_link(name):
@@ -157,11 +161,11 @@ def add_plover_API(APInames:dict[str, str], metaKG:pd.DataFrame) -> tuple[dict[s
             for i in range(len(data["edges"])):
                 APInames, metaKG = add_new_API_for_query(APInames, metaKG, "CATRAX BigGIM DrugResponse Performance Phase KP - TRAPI 1.5.0", "https://multiomics.rtx.ai:9990/BigGIM_DrugResponse_PerformancePhase/query", data["edges"][i]['predicate'], data["edges"][i]['subject'], data["edges"][i]['object'])
         else:
-            print("Warning: Failed to retrieve data from the https://multiomics.rtx.ai:9990/BigGIM_DrugResponse_PerformancePhase. Status code:", response.status_code)
+            logger.warning("Failed to retrieve data from %s. Status code: %s", "https://multiomics.rtx.ai:9990/BigGIM_DrugResponse_PerformancePhase", response.status_code)
 
 
     except requests.exceptions.RequestException:
-        print("Warning: Failed to retrieve data from the https://multiomics.rtx.ai:9990/BigGIM_DrugResponse_PerformancePhase")
+        logger.warning("Failed to retrieve data from %s", "https://multiomics.rtx.ai:9990/BigGIM_DrugResponse_PerformancePhase")
 
 
     
@@ -173,9 +177,9 @@ def add_plover_API(APInames:dict[str, str], metaKG:pd.DataFrame) -> tuple[dict[s
             for i in range(len(data["edges"])):
                 APInames, metaKG = add_new_API_for_query(APInames, metaKG, "CATRAX Pharmacogenomics KP - TRAPI 1.5.0", "https://multiomics.rtx.ai:9990/PharmacogenomicsKG/query", data["edges"][i]['predicate'], data["edges"][i]['subject'], data["edges"][i]['object'])
         else:
-            print("Warning: Failed to retrieve data from the https://multiomics.rtx.ai:9990/PharmacogenomicsKG. Status code:", response.status_code)
+            logger.warning("Failed to retrieve data from %s. Status code: %s", "https://multiomics.rtx.ai:9990/PharmacogenomicsKG", response.status_code)
     except requests.exceptions.RequestException:
-        print("Warning: Failed to retrieve data from the https://multiomics.rtx.ai:9990/PharmacogenomicsKG")
+        logger.warning("Failed to retrieve data from %s", "https://multiomics.rtx.ai:9990/PharmacogenomicsKG")
 
     
 
@@ -187,9 +191,9 @@ def add_plover_API(APInames:dict[str, str], metaKG:pd.DataFrame) -> tuple[dict[s
             for i in range(len(data["edges"])):
                 APInames, metaKG = add_new_API_for_query(APInames, metaKG, "Clinical Trials KP - TRAPI 1.5.0", "https://multiomics.rtx.ai:9990/ctkp/query", data["edges"][i]['predicate'], data["edges"][i]['subject'], data["edges"][i]['object'])
         else:
-            print("Warning: Failed to retrieve data from the https://multiomics.rtx.ai:9990/ctkp. Status code:", response.status_code)
+            logger.warning("Failed to retrieve data from %s. Status code: %s", "https://multiomics.rtx.ai:9990/ctkp", response.status_code)
     except requests.exceptions.RequestException:
-        print("Warning: Failed to retrieve data from the https://multiomics.rtx.ai:9990/ctkp")
+        logger.warning("Failed to retrieve data from %s", "https://multiomics.rtx.ai:9990/ctkp")
 
     
 
@@ -201,9 +205,9 @@ def add_plover_API(APInames:dict[str, str], metaKG:pd.DataFrame) -> tuple[dict[s
             for i in range(len(data["edges"])):
                 APInames, metaKG = add_new_API_for_query(APInames, metaKG, "Drug Approvals KP - TRAPI 1.5.0", "https://multiomics.rtx.ai:9990/dakp/query", data["edges"][i]['predicate'], data["edges"][i]['subject'], data["edges"][i]['object'])
         else:
-            print("Warning: Failed to retrieve data from the https://multiomics.rtx.ai:9990/dakp. Status code:", response.status_code)
+            logger.warning("Failed to retrieve data from %s. Status code: %s", "https://multiomics.rtx.ai:9990/dakp", response.status_code)
     except requests.exceptions.RequestException:
-        print("Warning: Failed to retrieve data from the https://multiomics.rtx.ai:9990/dakp")
+        logger.warning("Failed to retrieve data from %s", "https://multiomics.rtx.ai:9990/dakp")
     
     
     url = 'https://multiomics.rtx.ai:9990/mokp/meta_knowledge_graph'
@@ -214,9 +218,9 @@ def add_plover_API(APInames:dict[str, str], metaKG:pd.DataFrame) -> tuple[dict[s
             for i in range(len(data["edges"])):
                 APInames, metaKG = add_new_API_for_query(APInames, metaKG, "Multiomics KP - TRAPI 1.5.0", "https://multiomics.rtx.ai:9990/multiomics/query", data["edges"][i]['predicate'], data["edges"][i]['subject'], data["edges"][i]['object'])
         else:
-            print("Warning: Failed to retrieve data from the https://multiomics.rtx.ai:9990/mokp. Status code:", response.status_code)
+            logger.warning("Failed to retrieve data from %s. Status code: %s", "https://multiomics.rtx.ai:9990/mokp", response.status_code)
     except requests.exceptions.RequestException:
-        print("Warning: Failed to retrieve data from the https://multiomics.rtx.ai:9990/mokp")
+        logger.warning("Failed to retrieve data from %s", "https://multiomics.rtx.ai:9990/mokp")
     
     url = 'https://multiomics.rtx.ai:9990/mbkp/meta_knowledge_graph'
     try:
@@ -226,9 +230,9 @@ def add_plover_API(APInames:dict[str, str], metaKG:pd.DataFrame) -> tuple[dict[s
             for i in range(len(data["edges"])):
                 APInames, metaKG = add_new_API_for_query(APInames, metaKG, "Microbiome KP - TRAPI 1.5.0", "https://multiomics.rtx.ai:9990/mbkp/query", data["edges"][i]['predicate'], data["edges"][i]['subject'], data["edges"][i]['object'])
         else:
-            print("Warning: Failed to retrieve data from the https://multiomics.rtx.ai:9990/mbkp. Status code:", response.status_code)
+            logger.warning("Failed to retrieve data from %s. Status code: %s", "https://multiomics.rtx.ai:9990/mbkp", response.status_code)
     except requests.exceptions.RequestException:
-        print("Warning: Failed to retrieve data from the https://multiomics.rtx.ai:9990/mbkp")
+        logger.warning("Failed to retrieve data from %s", "https://multiomics.rtx.ai:9990/mbkp")
     
 
     url = 'https://kg2cploverdb.ci.transltr.io/meta_knowledge_graph'
@@ -239,9 +243,9 @@ def add_plover_API(APInames:dict[str, str], metaKG:pd.DataFrame) -> tuple[dict[s
             for i in range(len(data["edges"])):
                 APInames, metaKG = add_new_API_for_query(APInames, metaKG, "RTX KG2 - TRAPI 1.5.0", "https://kg2cploverdb.ci.transltr.io/kg2c/query", data["edges"][i]['predicate'], data["edges"][i]['subject'], data["edges"][i]['object'])
         else:
-            print("Warning: Failed to retrieve data from the https://kg2cploverdb.ci.transltr.io. Status code:", response.status_code)
+            logger.warning("Failed to retrieve data from %s. Status code: %s", "https://kg2cploverdb.ci.transltr.io", response.status_code)
     except requests.exceptions.RequestException:
-        print("Warning: Failed to retrieve data from the https://kg2cploverdb.ci.transltr.io")
+        logger.warning("Failed to retrieve data from %s", "https://kg2cploverdb.ci.transltr.io")
 
     return APInames, metaKG
 

--- a/src/translator_component_toolkit/translator_query.py
+++ b/src/translator_component_toolkit/translator_query.py
@@ -1,8 +1,11 @@
+import logging
 import requests
 from copy import deepcopy
 import pandas
 from . import translator_metakg
 from . import translator_kpinfo
+
+logger = logging.getLogger(__name__)
 
 
 def get_translator_API_predicates() -> tuple[dict, pandas.DataFrame, dict]:
@@ -25,13 +28,13 @@ def get_translator_API_predicates() -> tuple[dict, pandas.DataFrame, dict]:
     >>> API_names, metaKG, API_predicates = get_translator_API_predicates()
     '''
     Translator_KP_info,APInames= translator_kpinfo.get_translator_kp_info()
-    print(len(Translator_KP_info))
+    logger.debug("Translator KP info count: %s", len(Translator_KP_info))
     # Step 2: Get metaKG and all predicates from Translator APIs through the SmartAPI system
-    metaKG = translator_metakg.get_KP_metadata(APInames) 
-    print(metaKG.shape)
+    metaKG = translator_metakg.get_KP_metadata(APInames)
+    logger.debug("metaKG shape: %s", metaKG.shape)
     # Add metaKG from Plover API based KG resources
     APInames,metaKG = translator_metakg.add_plover_API(APInames, metaKG)
-    print(metaKG.shape)
+    logger.debug("metaKG shape after plover: %s", metaKG.shape)
     # Step 3: list metaKG information
     # All_predicates = list(set(metaKG['Predicate']))  # Unused variable
     # All_categories = list((set(list(set(metaKG['Subject']))+list(set(metaKG['Object'])))))  # Unused variable
@@ -179,7 +182,7 @@ def query_KP(API_name_cur, query_json, APInames, API_predicates):
         kg = result.get("knowledge_graph", {})
         edges = kg.get("edges", {})
         if edges:
-            print(f"{API_name_cur}: Success!")
+            logger.info("%s: Success!", API_name_cur)
             return result
         elif "knowledge_graph" in result:
             return None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,9 +1,20 @@
 """Tests for the registry-generated CLI."""
 
+import requests
 from click.testing import CliRunner
 
+from translator_component_toolkit import name_resolver
 from translator_component_toolkit.cli import main
+from translator_component_toolkit.errors import InvalidParameterError
+from translator_component_toolkit.io import (
+    EXIT_NOT_FOUND,
+    EXIT_OK,
+    EXIT_UNEXPECTED,
+    EXIT_UPSTREAM,
+    EXIT_USAGE,
+)
 from translator_component_toolkit.schema import REGISTRY
+from translator_component_toolkit.translator_node import TranslatorNode
 
 
 def test_cli_help():
@@ -48,5 +59,68 @@ def test_invalid_json_argument_is_rejected():
     runner = CliRunner()
     # get-metakg takes a JSON dict argument; pass invalid JSON
     result = runner.invoke(main, ["metakg", "get-metakg", "{not json"])
-    assert result.exit_code != 0
+    assert result.exit_code == EXIT_USAGE
     assert "valid JSON" in result.output
+
+
+def test_lookup_error_exits_not_found(monkeypatch):
+    def boom(*args, **kwargs):
+        raise LookupError("no match for 'ZZZ'")
+
+    monkeypatch.setattr(name_resolver, "lookup", boom)
+    runner = CliRunner()
+    result = runner.invoke(main, ["name", "lookup-name", "ZZZ"])
+    assert result.exit_code == EXIT_NOT_FOUND
+    assert "no match" in result.stderr
+
+
+def test_request_exception_exits_upstream(monkeypatch):
+    def boom(*args, **kwargs):
+        raise requests.RequestException("connection refused")
+
+    monkeypatch.setattr(name_resolver, "lookup", boom)
+    runner = CliRunner()
+    result = runner.invoke(main, ["name", "lookup-name", "AML"])
+    assert result.exit_code == EXIT_UPSTREAM
+    assert "upstream" in result.stderr
+
+
+def test_unexpected_exception_exits_one(monkeypatch):
+    def boom(*args, **kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(name_resolver, "lookup", boom)
+    runner = CliRunner()
+    result = runner.invoke(main, ["name", "lookup-name", "AML"])
+    assert result.exit_code == EXIT_UNEXPECTED
+
+
+def test_invalid_parameter_exits_usage():
+    runner = CliRunner()
+    # query-kp validates api_name against the (empty) api_names dict.
+    result = runner.invoke(main, ["query", "query-kp", "Unknown", "{}", "{}", "{}"])
+    assert result.exit_code == EXIT_USAGE
+
+
+def test_data_goes_to_stdout_as_json(monkeypatch):
+    node = TranslatorNode(curie="MONDO:0018874", label="acute myeloid leukemia")
+    monkeypatch.setattr(name_resolver, "lookup", lambda *a, **k: node)
+    runner = CliRunner()
+    result = runner.invoke(main, ["name", "lookup-name", "AML"])
+    assert result.exit_code == EXIT_OK
+    assert '"curie": "MONDO:0018874"' in result.output
+
+
+def test_no_json_flag_emits_plain_repr(monkeypatch):
+    node = TranslatorNode(curie="MONDO:0018874", label="acute myeloid leukemia")
+    monkeypatch.setattr(name_resolver, "lookup", lambda *a, **k: node)
+    runner = CliRunner()
+    result = runner.invoke(main, ["--no-json", "name", "lookup-name", "AML"])
+    assert result.exit_code == EXIT_OK
+    assert "MONDO:0018874" in result.output
+    assert '"curie"' not in result.output
+
+
+def test_invalid_parameter_error_is_importable():
+    # Guards the CLI's exception mapping import.
+    assert issubclass(InvalidParameterError, ValueError)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,0 +1,65 @@
+"""Tests for the output serializer and exit-code constants."""
+
+import pandas as pd
+
+from translator_component_toolkit.io import (
+    EXIT_NOT_FOUND,
+    EXIT_OK,
+    EXIT_UNEXPECTED,
+    EXIT_UPSTREAM,
+    EXIT_USAGE,
+    serialize,
+)
+from translator_component_toolkit.translator_node import TranslatorNode
+
+
+def test_primitives_pass_through():
+    assert serialize("a") == "a"
+    assert serialize(3) == 3
+    assert serialize(1.5) == 1.5
+    assert serialize(True) is True
+    assert serialize(None) is None
+
+
+def test_dataclass_serializes_to_dict():
+    node = TranslatorNode(curie="MONDO:1", label="x", types=["biolink:Disease"])
+    result = serialize(node)
+    assert result["curie"] == "MONDO:1"
+    assert result["label"] == "x"
+    assert result["types"] == ["biolink:Disease"]
+
+
+def test_dataframe_serializes_to_records():
+    df = pd.DataFrame({"a": [1, 2], "b": ["x", "y"]})
+    result = serialize(df)
+    assert result == [{"a": 1, "b": "x"}, {"a": 2, "b": "y"}]
+
+
+def test_tuple_becomes_list():
+    assert serialize((1, 2, 3)) == [1, 2, 3]
+
+
+def test_nested_structures_are_serialized():
+    node = TranslatorNode(curie="C:1")
+    payload = {"nodes": [node], "meta": ("a", "b")}
+    result = serialize(payload)
+    assert result["nodes"][0]["curie"] == "C:1"
+    assert result["meta"] == ["a", "b"]
+
+
+def test_dict_keys_coerced_to_str():
+    assert serialize({1: "a"}) == {"1": "a"}
+
+
+def test_unknown_object_falls_back_to_str():
+    class Weird:
+        def __str__(self):
+            return "weird"
+
+    assert serialize(Weird()) == "weird"
+
+
+def test_exit_codes_are_distinct():
+    codes = {EXIT_OK, EXIT_USAGE, EXIT_NOT_FOUND, EXIT_UPSTREAM, EXIT_UNEXPECTED}
+    assert len(codes) == 5
+    assert EXIT_OK == 0


### PR DESCRIPTION
## Summary
- Adds `src/translator_component_toolkit/io.py` with `serialize()` normalizing `TranslatorNode`/dataclasses (`asdict`), DataFrames (records), and tuples into JSON-safe primitives, plus documented exit-code constants.
- CLI now emits data to **stdout** (JSON by default via `--json`, plain repr via `--no-json`) and diagnostics to **stderr**.
- Exception-to-exit-code mapping: `0` ok, `2` usage/invalid parameter, `3` not found (`LookupError`), `4` upstream (`RequestException`), `1` unexpected.
- Replaces library `print(...)` with module loggers in `translator_kpinfo`, `translator_query`, `translator_metakg`, `node_normalizer`, and fixes the `translator_kpinfo` `exit()` bug so a failed download raises `RequestException` instead of killing the process.

## Test plan
- [x] `serialize` handles primitives, dataclasses, DataFrames, tuples, nested structures, fallback to str
- [x] Exit codes verified via `CliRunner` (not-found, upstream, unexpected, usage)
- [x] Data → stdout as JSON; `--no-json` emits plain repr; errors → stderr
- [x] Full suite green (88 passed, 1 skipped); ruff clean on changed files
- [x] MCP smoke: 23 tools still register

Closes #8