### PR TITLE
Add bounded responses for list-style tools

### DIFF
--- a/src/translator_component_toolkit/io.py
+++ b/src/translator_component_toolkit/io.py
@@ -54,3 +54,34 @@ def serialize(obj: Any) -> Any:
         return [serialize(v) for v in obj]
 
     return str(obj)
+
+
+def paginate(items: Any, limit: int | None = None, offset: int = 0) -> dict[str, Any]:
+    """Wrap a list-style result in a bounded response envelope.
+
+    The result is serialized, coerced to a list, then sliced by ``offset`` and
+    ``limit``. The envelope makes truncation explicit so an agent knows whether
+    to fetch more:
+
+    ``{"data": [...], "total": N, "returned": k, "truncated": bool,
+    "next_offset": int | None}``
+
+    A ``limit`` of ``None`` returns everything from ``offset`` onward.
+    """
+    serialized = serialize(items)
+    if not isinstance(serialized, list):
+        serialized = [serialized]
+
+    total = len(serialized)
+    start = max(offset, 0)
+    page = serialized[start:] if limit is None else serialized[start:start + limit]
+    returned = len(page)
+    consumed = start + returned
+    truncated = consumed < total
+    return {
+        "data": page,
+        "total": total,
+        "returned": returned,
+        "truncated": truncated,
+        "next_offset": consumed if truncated else None,
+    }

--- a/src/translator_component_toolkit/schema.py
+++ b/src/translator_component_toolkit/schema.py
@@ -21,6 +21,7 @@ from typing import Any
 
 from . import name_resolver, node_normalizer, translator_kpinfo, translator_metakg, translator_query, trapi
 from .errors import validate_choice
+from .io import paginate
 
 
 @dataclass(frozen=True)
@@ -72,6 +73,9 @@ class ToolSpec:
         CLI command group (e.g. ``name``, ``query``).
     output_hint : str | None
         Optional note about the return shape.
+    paginated : bool
+        Whether the tool accepts ``limit``/``offset`` and returns a bounded
+        response envelope (see :func:`io.paginate`).
     """
 
     name: str
@@ -81,6 +85,7 @@ class ToolSpec:
     aliases: list[str] = field(default_factory=list)
     group: str = "misc"
     output_hint: str | None = None
+    paginated: bool = False
 
 
 def make_signed_callable(spec: ToolSpec) -> Callable[..., Any]:
@@ -148,8 +153,13 @@ def _get_kp_info() -> Any:
     return translator_kpinfo.get_translator_kp_info()
 
 
-def _get_metakg_data(api_names: dict) -> Any:
-    return translator_metakg.get_KP_metadata(api_names)
+def _get_metakg_data(api_names: dict, limit: int | None = None, offset: int = 0) -> Any:
+    result = translator_metakg.get_KP_metadata(api_names)
+    # Preserve the raw DataFrame when unbounded so downstream tools (e.g.
+    # add_metakg_api) can keep chaining on it; otherwise return an envelope.
+    if limit is None and offset == 0:
+        return result
+    return paginate(result, limit, offset)
 
 
 def _add_custom_api_to_metakg(api_names: dict, metakg_df: Any, new_api_name: str, new_api_url: str,
@@ -255,8 +265,14 @@ REGISTRY: list[ToolSpec] = [
         summary="Get MetaKG metadata (predicates, subjects, objects) for Knowledge Providers.",
         func=_get_metakg_data,
         group="metakg",
-        params=[ParamSpec("api_names", dict, required=True, help="Dictionary mapping API names to URLs.")],
-        output_hint="DataFrame",
+        paginated=True,
+        params=[
+            ParamSpec("api_names", dict, required=True, help="Dictionary mapping API names to URLs."),
+            ParamSpec("limit", int, default=None,
+                      help="Max rows to return; omit for the full DataFrame (chainable)."),
+            ParamSpec("offset", int, default=0, help="Row offset when paginating."),
+        ],
+        output_hint="DataFrame, or bounded envelope {data, total, returned, truncated, next_offset} when limit/offset given",
     ),
     ToolSpec(
         name="add_metakg_api",

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -8,6 +8,7 @@ from translator_component_toolkit.io import (
     EXIT_UNEXPECTED,
     EXIT_UPSTREAM,
     EXIT_USAGE,
+    paginate,
     serialize,
 )
 from translator_component_toolkit.translator_node import TranslatorNode
@@ -63,3 +64,47 @@ def test_exit_codes_are_distinct():
     codes = {EXIT_OK, EXIT_USAGE, EXIT_NOT_FOUND, EXIT_UPSTREAM, EXIT_UNEXPECTED}
     assert len(codes) == 5
     assert EXIT_OK == 0
+
+
+def test_paginate_limit_truncates_and_sets_metadata():
+    env = paginate(list(range(10)), limit=3, offset=0)
+    assert env["data"] == [0, 1, 2]
+    assert env["total"] == 10
+    assert env["returned"] == 3
+    assert env["truncated"] is True
+    assert env["next_offset"] == 3
+
+
+def test_paginate_offset_advances_window():
+    env = paginate(list(range(10)), limit=3, offset=3)
+    assert env["data"] == [3, 4, 5]
+    assert env["next_offset"] == 6
+
+
+def test_paginate_last_page_is_not_truncated():
+    env = paginate(list(range(5)), limit=3, offset=3)
+    assert env["data"] == [3, 4]
+    assert env["truncated"] is False
+    assert env["next_offset"] is None
+
+
+def test_paginate_no_limit_returns_everything():
+    env = paginate(list(range(4)))
+    assert env["data"] == [0, 1, 2, 3]
+    assert env["total"] == 4
+    assert env["truncated"] is False
+    assert env["next_offset"] is None
+
+
+def test_paginate_serializes_dataframe_records():
+    df = pd.DataFrame({"a": [1, 2, 3]})
+    env = paginate(df, limit=2)
+    assert env["data"] == [{"a": 1}, {"a": 2}]
+    assert env["total"] == 3
+    assert env["truncated"] is True
+
+
+def test_paginate_wraps_non_list_as_single_item():
+    env = paginate({"k": "v"})
+    assert env["data"] == [{"k": "v"}]
+    assert env["total"] == 1

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -112,3 +112,40 @@ def test_signed_callable_binds_and_delegates():
     signed = make_signed_callable(spec)
     signed(1)
     assert captured == {"a": 1, "b": 2}
+
+
+def test_paginated_tools_expose_limit_and_offset():
+    for spec in REGISTRY:
+        if spec.paginated:
+            names = {p.name for p in spec.params}
+            assert {"limit", "offset"} <= names, f"{spec.name} paginated but missing limit/offset"
+
+
+def test_get_metakg_is_paginated():
+    by_name = {spec.name: spec for spec in REGISTRY}
+    assert by_name["get_metakg"].paginated is True
+
+
+def test_get_metakg_returns_raw_when_unbounded(monkeypatch):
+    import pandas as pd
+
+    from translator_component_toolkit import schema, translator_metakg
+
+    df = pd.DataFrame({"API": ["x", "y"], "Predicate": ["p", "q"]})
+    monkeypatch.setattr(translator_metakg, "get_KP_metadata", lambda api_names: df)
+    result = schema._get_metakg_data({"x": "http://x"})
+    assert result is df  # unchanged shape preserves chaining
+
+
+def test_get_metakg_returns_envelope_when_limited(monkeypatch):
+    import pandas as pd
+
+    from translator_component_toolkit import schema, translator_metakg
+
+    df = pd.DataFrame({"API": ["x", "y", "z"]})
+    monkeypatch.setattr(translator_metakg, "get_KP_metadata", lambda api_names: df)
+    result = schema._get_metakg_data({"x": "http://x"}, limit=2)
+    assert result["total"] == 3
+    assert result["returned"] == 2
+    assert result["truncated"] is True
+    assert result["next_offset"] == 2


### PR DESCRIPTION
## Summary
- Adds a generic `paginate()` helper to `io.py` that wraps a list/DataFrame in a response envelope: `{data, total, returned, truncated, next_offset}`, making truncation explicit so an agent knows whether to fetch more.
- Adds a `paginated` flag to `ToolSpec` and exposes optional `limit`/`offset` parameters on `get_metakg` (the largest payload, capped at 5000 rows upstream).
- Pagination is **opt-in**: omitting `limit`/`offset` returns the raw DataFrame so downstream tools (e.g. `add_metakg_api`) keep chaining on it unchanged.

## Test plan
- [x] `paginate` truncation/offset/last-page/no-limit metadata
- [x] `paginate` serializes DataFrame records and wraps non-lists
- [x] `get_metakg` returns the raw DataFrame when unbounded, an envelope when limited
- [x] Paginated tools expose `limit`/`offset`; `--limit`/`--offset` appear on the CLI
- [x] Full suite green (98 passed, 1 skipped); ruff clean on changed files

Closes #9