### PR TITLE
Resolve read-path catalog from a cache instead of threading it through calls

### DIFF
--- a/src/translator_component_toolkit/catalog.py
+++ b/src/translator_component_toolkit/catalog.py
@@ -1,0 +1,75 @@
+"""
+Process-wide cache of the Translator reference catalog.
+
+The foundational reference data — the map of API names to URLs, the MetaKG, and
+each API's supported predicates — is slow-changing but expensive to build
+(several HTTP calls over ~1000 SmartAPI specs plus per-KP metakg fetches). The
+library produces all three together in :func:`translator_query.get_translator_API_predicates`,
+where ``api_predicates`` is derived from the MetaKG, which is derived from
+``api_names``.
+
+Caching that bundle here lets read-path tools resolve it on demand instead of
+forcing agents to fetch it and thread it back through every call. Tools keep
+explicit parameters as an override; the cache is only consulted when a caller
+omits them.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+from . import translator_query
+
+# A builder returns the foundational bundle ``(api_names, metakg, api_predicates)``.
+CatalogBuilder = Callable[[], tuple[dict, Any, dict]]
+
+
+@dataclass(frozen=True)
+class Catalog:
+    """The foundational Translator reference data, built as one bundle.
+
+    Attributes
+    ----------
+    api_names : dict[str, str]
+        Map of API name to query URL.
+    metakg : Any
+        The MetaKG ``pandas.DataFrame`` (kept as ``Any`` to avoid importing
+        pandas eagerly here).
+    api_predicates : dict[str, list]
+        Map of API name to the list of predicates it supports.
+    """
+
+    api_names: dict[str, str]
+    metakg: Any
+    api_predicates: dict[str, list]
+
+
+_CACHE: Catalog | None = None
+
+
+def _default_builder() -> tuple[dict, Any, dict]:
+    return translator_query.get_translator_API_predicates()
+
+
+def get_catalog(force_refresh: bool = False, builder: CatalogBuilder | None = None) -> Catalog:
+    """Return the cached :class:`Catalog`, building it on first use.
+
+    The bundle is built once via ``builder`` (defaulting to
+    :func:`translator_query.get_translator_API_predicates`) and reused. Pass
+    ``force_refresh=True`` to rebuild (e.g. after the upstream registry
+    changes). ``builder`` is an injection seam for tests.
+    """
+    global _CACHE
+    if _CACHE is None or force_refresh:
+        build = builder or _default_builder
+        api_names, metakg, api_predicates = build()
+        _CACHE = Catalog(api_names, metakg, api_predicates)
+    return _CACHE
+
+
+def reset_cache() -> None:
+    """Drop the cached catalog (primarily for tests)."""
+    global _CACHE
+    _CACHE = None

--- a/src/translator_component_toolkit/schema.py
+++ b/src/translator_component_toolkit/schema.py
@@ -19,7 +19,7 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any
 
-from . import name_resolver, node_normalizer, translator_kpinfo, translator_metakg, translator_query, trapi
+from . import catalog, name_resolver, node_normalizer, translator_kpinfo, translator_metakg, translator_query, trapi
 from .errors import validate_choice
 from .io import paginate
 
@@ -153,8 +153,13 @@ def _get_kp_info() -> Any:
     return translator_kpinfo.get_translator_kp_info()
 
 
-def _get_metakg_data(api_names: dict, limit: int | None = None, offset: int = 0) -> Any:
-    result = translator_metakg.get_KP_metadata(api_names)
+def _get_metakg_data(api_names: dict | None = None, limit: int | None = None, offset: int = 0) -> Any:
+    # Omit api_names to use the cached Translator catalog's MetaKG; supply it to
+    # build the MetaKG for a specific set of APIs (explicit override).
+    if api_names is None:
+        result = catalog.get_catalog().metakg
+    else:
+        result = translator_metakg.get_KP_metadata(api_names)
     # Preserve the raw DataFrame when unbounded so downstream tools (e.g.
     # add_metakg_api) can keep chaining on it; otherwise return an envelope.
     if limit is None and offset == 0:
@@ -177,18 +182,33 @@ def _get_api_predicates() -> Any:
     return translator_query.get_translator_API_predicates()
 
 
-def _optimize_query_for_api(query_json: dict, api_name: str, api_predicates: dict) -> Any:
+def _optimize_query_for_api(query_json: dict, api_name: str, api_predicates: dict | None = None) -> Any:
+    if api_predicates is None:
+        api_predicates = catalog.get_catalog().api_predicates
     validate_choice(api_name, api_predicates.keys(), "api_name")
     return translator_query.optimize_query_json(query_json, api_name, api_predicates)
 
 
-def _query_knowledge_provider(api_name: str, query_json: dict, api_names: dict, api_predicates: dict) -> Any:
+def _query_knowledge_provider(api_name: str, query_json: dict, api_names: dict | None = None,
+                              api_predicates: dict | None = None) -> Any:
+    # Resolve api_names first and validate before fetching api_predicates, so
+    # bad input fails fast without an extra catalog build.
+    if api_names is None:
+        api_names = catalog.get_catalog().api_names
     validate_choice(api_name, api_names.keys(), "api_name")
+    if api_predicates is None:
+        api_predicates = catalog.get_catalog().api_predicates
     return translator_query.query_KP(api_name, query_json, api_names, api_predicates)
 
 
-def _parallel_query_apis(query_json: dict, selected_apis: list[str], api_names: dict, api_predicates: dict,
-                         max_workers: int = 1) -> Any:
+def _parallel_query_apis(query_json: dict, selected_apis: list[str], api_names: dict | None = None,
+                         api_predicates: dict | None = None, max_workers: int = 1) -> Any:
+    if api_names is None or api_predicates is None:
+        cat = catalog.get_catalog()
+        if api_names is None:
+            api_names = cat.api_names
+        if api_predicates is None:
+            api_predicates = cat.api_predicates
     return translator_query.parallel_api_query(query_json, selected_apis, api_names, api_predicates, max_workers)
 
 
@@ -267,7 +287,8 @@ REGISTRY: list[ToolSpec] = [
         group="metakg",
         paginated=True,
         params=[
-            ParamSpec("api_names", dict, required=True, help="Dictionary mapping API names to URLs."),
+            ParamSpec("api_names", dict, default=None,
+                      help="Map of API names to URLs; omit to use the cached Translator catalog."),
             ParamSpec("limit", int, default=None,
                       help="Max rows to return; omit for the full DataFrame (chainable)."),
             ParamSpec("offset", int, default=0, help="Row offset when paginating."),
@@ -319,7 +340,8 @@ REGISTRY: list[ToolSpec] = [
         params=[
             ParamSpec("query_json", dict, required=True, help="TRAPI 1.5.0 format query."),
             ParamSpec("api_name", str, required=True, help="Name of the API to query."),
-            ParamSpec("api_predicates", dict, required=True, help="Dictionary of API names to their predicates."),
+            ParamSpec("api_predicates", dict, default=None,
+                      help="Map of API names to predicates; omit to use the cached Translator catalog."),
         ],
         output_hint="dict (modified query)",
     ),
@@ -332,8 +354,10 @@ REGISTRY: list[ToolSpec] = [
         params=[
             ParamSpec("api_name", str, required=True, help="Name of the API to query."),
             ParamSpec("query_json", dict, required=True, help="TRAPI 1.5.0 format query."),
-            ParamSpec("api_names", dict, required=True, help="Dictionary mapping API names to URLs."),
-            ParamSpec("api_predicates", dict, required=True, help="Dictionary of API names to their predicates."),
+            ParamSpec("api_names", dict, default=None,
+                      help="Map of API names to URLs; omit to use the cached Translator catalog."),
+            ParamSpec("api_predicates", dict, default=None,
+                      help="Map of API names to predicates; omit to use the cached Translator catalog."),
         ],
         output_hint="dict (knowledge graph) or None",
     ),
@@ -346,8 +370,10 @@ REGISTRY: list[ToolSpec] = [
         params=[
             ParamSpec("query_json", dict, required=True, help="TRAPI 1.5.0 format query."),
             ParamSpec("selected_apis", list[str], required=True, help="List of API names to query."),
-            ParamSpec("api_names", dict, required=True, help="Dictionary mapping API names to URLs."),
-            ParamSpec("api_predicates", dict, required=True, help="Dictionary of API names to their predicates."),
+            ParamSpec("api_names", dict, default=None,
+                      help="Map of API names to URLs; omit to use the cached Translator catalog."),
+            ParamSpec("api_predicates", dict, default=None,
+                      help="Map of API names to predicates; omit to use the cached Translator catalog."),
             ParamSpec("max_workers", int, default=1, help="Number of parallel workers."),
         ],
         output_hint="dict (merged knowledge graph)",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,40 @@
+"""Shared fixtures for the test suite."""
+
+import pandas as pd
+import pytest
+
+from translator_component_toolkit import catalog
+
+
+@pytest.fixture(autouse=True)
+def reset_catalog():
+    """Keep the process-wide catalog cache from leaking across tests."""
+    catalog.reset_cache()
+    yield
+    catalog.reset_cache()
+
+
+@pytest.fixture
+def sample_bundle():
+    """A small foundational bundle: (api_names, metakg, api_predicates)."""
+    api_names = {"API X": "http://x"}
+    metakg = pd.DataFrame({"API": ["API X"], "Predicate": ["biolink:related_to"]})
+    api_predicates = {"API X": ["biolink:related_to"]}
+    return api_names, metakg, api_predicates
+
+
+@pytest.fixture
+def seeded_catalog(sample_bundle):
+    """Seed the cache with a known catalog so tools resolve from it offline."""
+    api_names, metakg, api_predicates = sample_bundle
+    cat = catalog.Catalog(api_names=api_names, metakg=metakg, api_predicates=api_predicates)
+    catalog._CACHE = cat
+    return cat
+
+
+@pytest.fixture
+def empty_catalog():
+    """Seed the cache with an empty catalog (no known APIs/predicates)."""
+    cat = catalog.Catalog(api_names={}, metakg=pd.DataFrame(), api_predicates={})
+    catalog._CACHE = cat
+    return cat

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1,0 +1,35 @@
+"""Tests for the process-wide reference catalog cache."""
+
+from unittest.mock import Mock
+
+from translator_component_toolkit import catalog
+
+
+def test_get_catalog_builds_once_and_caches(sample_bundle):
+    builder = Mock(return_value=sample_bundle)
+
+    first = catalog.get_catalog(builder=builder)
+    second = catalog.get_catalog(builder=builder)
+
+    assert builder.call_count == 1  # built once, then served from cache
+    assert first is second
+    assert first.api_names == {"API X": "http://x"}
+    assert first.api_predicates == {"API X": ["biolink:related_to"]}
+
+
+def test_force_refresh_rebuilds(sample_bundle):
+    builder = Mock(return_value=sample_bundle)
+
+    catalog.get_catalog(builder=builder)
+    catalog.get_catalog(builder=builder, force_refresh=True)
+
+    assert builder.call_count == 2
+
+
+def test_reset_cache_clears(sample_bundle):
+    builder = Mock(return_value=sample_bundle)
+    catalog.get_catalog(builder=builder)
+
+    catalog.reset_cache()
+
+    assert catalog._CACHE is None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -57,8 +57,8 @@ def test_required_argument_is_enforced():
 
 def test_invalid_json_argument_is_rejected():
     runner = CliRunner()
-    # get-metakg takes a JSON dict argument; pass invalid JSON
-    result = runner.invoke(main, ["metakg", "get-metakg", "{not json"])
+    # get-metakg takes an optional --api-names JSON dict; pass invalid JSON
+    result = runner.invoke(main, ["metakg", "get-metakg", "--api-names", "{not json"])
     assert result.exit_code == EXIT_USAGE
     assert "valid JSON" in result.output
 
@@ -97,8 +97,10 @@ def test_unexpected_exception_exits_one(monkeypatch):
 
 def test_invalid_parameter_exits_usage():
     runner = CliRunner()
-    # query-kp validates api_name against the (empty) api_names dict.
-    result = runner.invoke(main, ["query", "query-kp", "Unknown", "{}", "{}", "{}"])
+    # api_names/api_predicates are now optional options; passing an explicit
+    # empty api_names makes query-kp validate api_name against it (no catalog
+    # fetch, so no network) and fail with a usage error.
+    result = runner.invoke(main, ["query", "query-kp", "Unknown", "{}", "--api-names", "{}"])
     assert result.exit_code == EXIT_USAGE
 
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -2,6 +2,10 @@
 
 import inspect
 
+import pytest
+
+from translator_component_toolkit import schema
+from translator_component_toolkit.errors import InvalidParameterError
 from translator_component_toolkit.schema import (
     REGISTRY,
     ParamSpec,
@@ -149,3 +153,62 @@ def test_get_metakg_returns_envelope_when_limited(monkeypatch):
     assert result["returned"] == 2
     assert result["truncated"] is True
     assert result["next_offset"] == 2
+
+
+# ---------------------------------------------------------------------------
+# Read-path reshape: catalog-derivable params are optional (issue #16).
+# ---------------------------------------------------------------------------
+
+CATALOG_OPTIONAL = {
+    "get_metakg": {"api_names"},
+    "optimize_query": {"api_predicates"},
+    "query_kp": {"api_names", "api_predicates"},
+    "query_kps_parallel": {"api_names", "api_predicates"},
+}
+
+
+def _query_with_predicates(predicates):
+    """Minimal TRAPI query carrying the given edge predicates."""
+    return {"message": {"query_graph": {"edges": {"e00": {"predicates": list(predicates)}}}}}
+
+
+def test_catalog_derivable_params_are_optional():
+    by_name = {spec.name: spec for spec in REGISTRY}
+    for tool, optional_params in CATALOG_OPTIONAL.items():
+        params = {p.name: p for p in by_name[tool].params}
+        for name in optional_params:
+            assert not params[name].required, f"{tool}.{name} should be optional"
+            assert params[name].default is None, f"{tool}.{name} should default to None"
+
+
+def test_get_metakg_uses_catalog_when_api_names_omitted(seeded_catalog):
+    result = schema._get_metakg_data()  # no api_names -> cached MetaKG
+    assert result is seeded_catalog.metakg
+
+
+def test_optimize_query_resolves_predicates_from_catalog(seeded_catalog):
+    # api_predicates omitted -> resolved from the catalog; the supported
+    # predicate is kept and the unsupported one is dropped.
+    query = _query_with_predicates(["biolink:related_to", "biolink:unsupported"])
+    result = schema._optimize_query_for_api(query, "API X")
+    assert result["message"]["query_graph"]["edges"]["e00"]["predicates"] == ["biolink:related_to"]
+
+
+def test_optimize_query_unknown_api_validates_against_catalog(seeded_catalog):
+    query = _query_with_predicates(["biolink:related_to"])
+    with pytest.raises(InvalidParameterError):
+        schema._optimize_query_for_api(query, "Unknown API")
+
+
+def test_query_kp_resolves_api_names_from_catalog(empty_catalog):
+    # api_names omitted -> resolved from the (empty) catalog, so validation of
+    # an unknown api_name fails before any network call is attempted.
+    with pytest.raises(InvalidParameterError):
+        schema._query_knowledge_provider("Unknown", {})
+
+
+def test_query_kp_explicit_api_names_override_catalog(seeded_catalog):
+    # Explicit (empty) api_names are used instead of the seeded catalog, so the
+    # known "API X" is rejected.
+    with pytest.raises(InvalidParameterError):
+        schema._query_knowledge_provider("API X", {}, api_names={})


### PR DESCRIPTION
## Summary
- Adds a process-wide `catalog` cache that lazily builds the foundational `(api_names, metakg, api_predicates)` bundle once (via `get_translator_API_predicates()`) and reuses it.
- Makes `api_names`/`api_predicates` **optional** on the read-path tools (`get_metakg`, `optimize_query`, `query_kp`, `query_kps_parallel`): omit them to resolve from the catalog; supply them to override (non-breaking, mirroring how `get_metakg`'s `limit`/`offset` were made opt-in).
- `query_kp` validates `api_name` before fetching predicates, so bad input fails without an extra catalog build.

## Why
Tracing the code, `api_predicates` is derived from the MetaKG, which is derived from `api_names` — they are one catalog plus two projections, not independent inputs. Exposing them as required params leaked internal intermediates (RC1/RC2), put expensive slow-changing reference data on the query critical path (RC3), and required passing back pandas DataFrames that don't survive the JSON round trip (RC4). This is the **read-path** half of Tier 2 (Safety & State, decision 1) and needs **no server statefulness**. The mutate-then-query path (`add_metakg_api`/`add_plover_apis`) keeps its required `metakg_df` and is deferred to decision (2).

Closes #16.

## Test plan
- [x] `catalog` builds once, caches, rebuilds on `force_refresh`, and clears on `reset_cache` (pure pytest; `unittest.mock.Mock` for call counting; fixtures in `conftest.py`).
- [x] Read-path params are optional and default to `None` in the registry.
- [x] Catalog fallback verified offline: `get_metakg` returns the cached MetaKG; `optimize_query` resolves predicates and drops unsupported ones; `query_kp`/`optimize_query` validate `api_name` against the resolved catalog; explicit params override the catalog.
- [x] CLI tests updated for the now-optional (option, not positional) params.
- [x] Full suite: 107 passed, 1 skipped; `ruff check` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)