### PR TITLE
Add network timeouts to all agent-facing HTTP calls

### DIFF
--- a/src/translator_component_toolkit/config.py
+++ b/src/translator_component_toolkit/config.py
@@ -1,0 +1,36 @@
+"""
+Network configuration for agent-facing HTTP calls.
+
+A single, configurable default timeout (in seconds) applied to every outbound
+``requests`` call in the agent-facing modules. Without a timeout a hung upstream
+blocks a tool call forever; for an agent that looks like a stuck session with no
+error to react to. Override the value with the ``TCT_HTTP_TIMEOUT`` environment
+variable.
+"""
+
+from __future__ import annotations
+
+import os
+
+DEFAULT_HTTP_TIMEOUT = 30.0
+"""Seconds to wait on an outbound HTTP call before giving up."""
+
+_ENV_VAR = "TCT_HTTP_TIMEOUT"
+
+
+def http_timeout() -> float:
+    """Return the configured HTTP timeout in seconds.
+
+    Reads ``TCT_HTTP_TIMEOUT`` when set to a positive number; otherwise falls
+    back to :data:`DEFAULT_HTTP_TIMEOUT`. A missing, unparseable, or
+    non-positive value is treated as "use the default" so a bad env var can
+    never disable timeouts.
+    """
+    raw = os.environ.get(_ENV_VAR)
+    if raw is None:
+        return DEFAULT_HTTP_TIMEOUT
+    try:
+        value = float(raw)
+    except ValueError:
+        return DEFAULT_HTTP_TIMEOUT
+    return value if value > 0 else DEFAULT_HTTP_TIMEOUT

--- a/src/translator_component_toolkit/name_resolver.py
+++ b/src/translator_component_toolkit/name_resolver.py
@@ -7,6 +7,7 @@ import urllib.parse
 
 import requests
 
+from . import config
 from .translator_node import TranslatorNode
 
 URL = 'https://name-lookup.ci.transltr.io/'
@@ -16,7 +17,7 @@ def status():
     """
     Returns the status of the Name Resolver API.
     """
-    response = requests.get(URL + 'status')
+    response = requests.get(URL + 'status', timeout=config.http_timeout())
     response.raise_for_status()
     return response.json()
 
@@ -54,7 +55,7 @@ def lookup(query: str, return_top_response:bool=True, return_synonyms:bool=False
     # set autocomplete to be false by default
     if 'autocomplete' not in kwargs:
         kwargs['autocomplete'] = False
-    response = requests.get(path, params={'string': query, 'limit': limit, **kwargs})
+    response = requests.get(path, params={'string': query, 'limit': limit, **kwargs}, timeout=config.http_timeout())
     if response.status_code == 200:
         result = response.json()
         if len(result) == 0:
@@ -89,7 +90,7 @@ def synonyms(query: str|list, **kwargs):
     """
     path = urllib.parse.urljoin(URL, 'synonyms')
     # set autocomplete to be false by default
-    response = requests.get(path, params={'preferred_curies': query, **kwargs})
+    response = requests.get(path, params={'preferred_curies': query, **kwargs}, timeout=config.http_timeout())
     if response.status_code == 200:
         result = response.json()
         if len(result) == 0:
@@ -150,7 +151,7 @@ def batch_lookup(strings:list[str], size: int=25, return_top_response:bool=True,
             "strings": chunk,
             **kwargs
         }
-        response = requests.post(path, json = payload)
+        response = requests.post(path, json = payload, timeout=config.http_timeout())
         if response.status_code == 200:
             result = response.json()
             if(len(result) == 0):
@@ -194,7 +195,7 @@ def batch_synonyms(strings:list[str], size:int=50, **kwargs) -> dict:
     curies = {}
     for chunk in chunks:
         # set autocomplete to be false by default
-        response = requests.post(path, json={'preferred_curies': chunk, **kwargs})
+        response = requests.post(path, json={'preferred_curies': chunk, **kwargs}, timeout=config.http_timeout())
         if response.status_code == 200:
             result = response.json()
             if len(result) == 0:

--- a/src/translator_component_toolkit/node_normalizer.py
+++ b/src/translator_component_toolkit/node_normalizer.py
@@ -8,6 +8,7 @@ import urllib.parse
 
 import requests
 
+from . import config
 from .translator_node import TranslatorNode
 
 logger = logging.getLogger(__name__)
@@ -19,7 +20,7 @@ def status():
     """
     Returns the status of the Node Normalizer API.
     """
-    response = requests.get(f'{URL}status')
+    response = requests.get(f'{URL}status', timeout=config.http_timeout())
     response.raise_for_status()
     return response.json()
 
@@ -61,9 +62,9 @@ def get_normalized_nodes(query: str | list[str],
             json_query = [query]
         else:
             json_query = query
-        response = requests.post(path, json={'curies': json_query, **kwargs})
+        response = requests.post(path, json={'curies': json_query, **kwargs}, timeout=config.http_timeout())
     else:
-        response = requests.get(path, params={'curie': query, **kwargs})
+        response = requests.get(path, params={'curie': query, **kwargs}, timeout=config.http_timeout())
     if response.status_code == 200:
         result = response.json()
         normalized_dict = {}
@@ -168,7 +169,7 @@ def ID_convert_to_preferred_name_nodeNormalizer(id_list):
             "description": False,   # Change to True if you want descriptions from any identifiers we know about.
             "conflate": NODENORM_GENE_PROTEIN_CONFLATION,
             "drug_chemical_conflate": NODENORM_DRUG_CHEMICAL_CONFLATION,
-        })
+        }, timeout=config.http_timeout())
         if not response.ok:
             raise RuntimeError("Error: NodeNorm request failed with status code " + str(response.status_code))
 

--- a/src/translator_component_toolkit/translator_kpinfo.py
+++ b/src/translator_component_toolkit/translator_kpinfo.py
@@ -7,6 +7,8 @@ import requests
 import json
 import pandas as pd
 
+from . import config
+
 logger = logging.getLogger(__name__)
 
 """This is the root URL for the resource."""
@@ -33,7 +35,7 @@ def get_translator_kp_info() -> tuple[pd.DataFrame, dict[str, str]]:
     """
     # Get x-bte smartapi specs
     url = "https://smart-api.info/api/query?q=tags.name:translator AND tags.name:trapi&size=1000&sort=_seq_no&raw=1&fields=paths,servers,tags,components.x-bte*,info,_meta"
-    response = requests.get(url)
+    response = requests.get(url, timeout=config.http_timeout())
     try:
         response.raise_for_status()
     except requests.RequestException as e:

--- a/src/translator_component_toolkit/translator_metakg.py
+++ b/src/translator_component_toolkit/translator_metakg.py
@@ -4,6 +4,8 @@ import requests
 import json
 import pandas as pd
 
+from . import config
+
 logger = logging.getLogger(__name__)
 
 
@@ -66,10 +68,10 @@ def get_KP_metadata(APInames:dict[str, str]) -> pd.DataFrame:
     for KP in APInames.keys():
         json_text ={}
         if KP == "RTX KG2 - TRAPI 1.5.0": 
-            text =requests.get("https://smart-api.info/api/metakg/consolidated?size=20&q=%28api.x-translator.component%3AKP+AND+api.name%3ARTX+KG2+%5C-+TRAPI+1%5C.4%5C.0%29").text  # This works for the previous version
+            text =requests.get("https://smart-api.info/api/metakg/consolidated?size=20&q=%28api.x-translator.component%3AKP+AND+api.name%3ARTX+KG2+%5C-+TRAPI+1%5C.4%5C.0%29", timeout=config.http_timeout()).text  # This works for the previous version
             json_text = json.loads(text)
         else:   
-            text = requests.get(find_link(KP)).text
+            text = requests.get(find_link(KP), timeout=config.http_timeout()).text
             json_text = json.loads(text)
 
         for i in (json_text['hits']):
@@ -155,7 +157,7 @@ def add_plover_API(APInames:dict[str, str], metaKG:pd.DataFrame) -> tuple[dict[s
     import requests
     url = 'https://multiomics.rtx.ai:9990/BigGIM_DrugResponse_PerformancePhase/meta_knowledge_graph'
     try:
-        response = requests.get(url, timeout=5)
+        response = requests.get(url, timeout=config.http_timeout())
         if response.status_code == 200:
             data = response.json()
             for i in range(len(data["edges"])):
@@ -171,7 +173,7 @@ def add_plover_API(APInames:dict[str, str], metaKG:pd.DataFrame) -> tuple[dict[s
     
     url = 'https://multiomics.rtx.ai:9990/PharmacogenomicsKG/meta_knowledge_graph'
     try: 
-        response = requests.get(url)
+        response = requests.get(url, timeout=config.http_timeout())
         if response.status_code == 200:
             data = response.json()
             for i in range(len(data["edges"])):
@@ -185,7 +187,7 @@ def add_plover_API(APInames:dict[str, str], metaKG:pd.DataFrame) -> tuple[dict[s
 
     url = 'https://multiomics.rtx.ai:9990/ctkp/meta_knowledge_graph'
     try: 
-        response = requests.get(url)
+        response = requests.get(url, timeout=config.http_timeout())
         if response.status_code == 200:
             data = response.json()
             for i in range(len(data["edges"])):
@@ -199,7 +201,7 @@ def add_plover_API(APInames:dict[str, str], metaKG:pd.DataFrame) -> tuple[dict[s
 
     url = 'https://multiomics.rtx.ai:9990/dakp/meta_knowledge_graph'
     try:
-        response = requests.get(url)
+        response = requests.get(url, timeout=config.http_timeout())
         if response.status_code == 200:
             data = response.json()
             for i in range(len(data["edges"])):
@@ -212,7 +214,7 @@ def add_plover_API(APInames:dict[str, str], metaKG:pd.DataFrame) -> tuple[dict[s
     
     url = 'https://multiomics.rtx.ai:9990/mokp/meta_knowledge_graph'
     try:
-        response = requests.get(url)
+        response = requests.get(url, timeout=config.http_timeout())
         if response.status_code == 200:
             data = response.json()
             for i in range(len(data["edges"])):
@@ -224,7 +226,7 @@ def add_plover_API(APInames:dict[str, str], metaKG:pd.DataFrame) -> tuple[dict[s
     
     url = 'https://multiomics.rtx.ai:9990/mbkp/meta_knowledge_graph'
     try:
-        response = requests.get(url)
+        response = requests.get(url, timeout=config.http_timeout())
         if response.status_code == 200:
             data = response.json()
             for i in range(len(data["edges"])):
@@ -237,7 +239,7 @@ def add_plover_API(APInames:dict[str, str], metaKG:pd.DataFrame) -> tuple[dict[s
 
     url = 'https://kg2cploverdb.ci.transltr.io/meta_knowledge_graph'
     try:
-        response = requests.get(url)
+        response = requests.get(url, timeout=config.http_timeout())
         if response.status_code == 200:
             data = response.json()
             for i in range(len(data["edges"])):

--- a/src/translator_component_toolkit/translator_query.py
+++ b/src/translator_component_toolkit/translator_query.py
@@ -2,6 +2,7 @@ import logging
 import requests
 from copy import deepcopy
 import pandas
+from . import config
 from . import translator_metakg
 from . import translator_kpinfo
 
@@ -176,7 +177,7 @@ def query_KP(API_name_cur, query_json, APInames, API_predicates):
     query_copy = deepcopy(query_json)
     # optimize on our private copy
     query_json_cur = optimize_query_json(query_copy, API_name_cur, API_predicates)
-    response = requests.post(API_url_cur, json=query_json_cur)
+    response = requests.post(API_url_cur, json=query_json_cur, timeout=config.http_timeout())
     if response.status_code == 200:
         result = response.json().get("message", {})
         kg = result.get("knowledge_graph", {})

--- a/src/translator_component_toolkit/trapi.py
+++ b/src/translator_component_toolkit/trapi.py
@@ -9,6 +9,8 @@ import json
 
 import requests
 
+from . import config
+
 # TODO: incorporate object ids into the method.
 def build_query(subject_ids:list[str],
         object_categories:list[str], predicates:list[str],
@@ -121,7 +123,7 @@ def query(url:str, query:dict):
             "Use build_query(...) without return_json=True, "
             "or pass json.loads(query) instead."
         )
-    response = requests.post(url, json=query)
+    response = requests.post(url, json=query, timeout=config.http_timeout())
     if response.status_code == 200:
         # TODO
         result = response.json().get("message", {})

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,51 @@
+"""Tests for the shared HTTP timeout configuration."""
+
+from unittest.mock import Mock, patch
+
+from translator_component_toolkit import config, name_resolver, trapi
+
+
+def test_default_timeout_when_env_unset():
+    with patch.dict("os.environ", {}, clear=True):
+        assert config.http_timeout() == config.DEFAULT_HTTP_TIMEOUT
+
+
+def test_env_override_is_used():
+    with patch.dict("os.environ", {"TCT_HTTP_TIMEOUT": "5"}, clear=True):
+        assert config.http_timeout() == 5.0
+
+
+def test_unparseable_env_falls_back_to_default():
+    with patch.dict("os.environ", {"TCT_HTTP_TIMEOUT": "soon"}, clear=True):
+        assert config.http_timeout() == config.DEFAULT_HTTP_TIMEOUT
+
+
+def test_non_positive_env_falls_back_to_default():
+    with patch.dict("os.environ", {"TCT_HTTP_TIMEOUT": "0"}, clear=True):
+        assert config.http_timeout() == config.DEFAULT_HTTP_TIMEOUT
+
+
+def test_get_call_passes_timeout():
+    response = Mock()
+    response.json.return_value = {"status": "ok"}
+    with patch.object(name_resolver.requests, "get", return_value=response) as get:
+        name_resolver.status()
+    assert get.call_args.kwargs["timeout"] == config.DEFAULT_HTTP_TIMEOUT
+
+
+def test_post_call_passes_timeout():
+    response = Mock()
+    response.status_code = 200
+    response.json.return_value = {"message": {"knowledge_graph": {"edges": {"e00": {}}}}}
+    with patch.object(trapi.requests, "post", return_value=response) as post:
+        trapi.query("http://example/query", {"message": {}})
+    assert post.call_args.kwargs["timeout"] == config.DEFAULT_HTTP_TIMEOUT
+
+
+def test_call_honors_env_override():
+    response = Mock()
+    response.json.return_value = {"status": "ok"}
+    with patch.dict("os.environ", {"TCT_HTTP_TIMEOUT": "1.5"}, clear=True):
+        with patch.object(name_resolver.requests, "get", return_value=response) as get:
+            name_resolver.status()
+    assert get.call_args.kwargs["timeout"] == 1.5


### PR DESCRIPTION
## Summary
- Adds `config.http_timeout()`: one configurable timeout (env var `TCT_HTTP_TIMEOUT`, default 30s) for outbound HTTP.
- Applies `timeout=config.http_timeout()` to all 21 `requests.get`/`requests.post` calls in the agent-facing modules (`name_resolver`, `node_normalizer`, `translator_kpinfo`, `translator_metakg`, `translator_query`, `trapi`), replacing the lone hardcoded `timeout=5` for consistency.

Without a timeout, a hung upstream blocks a tool call indefinitely; an agent sees a stuck session with no error to react to.

Closes #18

## Notes
- Legacy modules not exposed through the registry (`TCT.py`, `TCT_pathfinder.py`, `graph_downloader.py`, `node_annotator.py`) are out of scope.
- Stacked on `feat/catalog-cache` (PR #17).

## Test plan
- [x] `config.http_timeout()` returns the default when the env var is unset, unparseable, or non-positive
- [x] `config.http_timeout()` honors a valid `TCT_HTTP_TIMEOUT` override
- [x] Representative GET (`name_resolver.status`) and POST (`trapi.query`) calls pass the timeout through, and honor the env override
- [x] Full suite: 114 passed, 1 skipped
- [x] `ruff check` clean on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)