### PR TITLE
Add MCP tool annotations to every registry tool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,11 +10,11 @@ test:
 
 # Run spell checking
 spell:
-	uv run codespell --skip=metaData,notebooks,htmlcov --ignore-words-list=EHR
+	uv run codespell --skip=metaData,notebooks,htmlcov,PathFinder_results --ignore-words-list=EHR
 
 # Run spell checking interactively (allows fixing)
 spell-fix:
-	uv run codespell --interactive 3 --skip=metaData,notebooks,htmlcov --ignore-words-list=EHR
+	uv run codespell --interactive 3 --skip=metaData,notebooks,htmlcov,PathFinder_results --ignore-words-list=EHR
 
 # Run linting
 lint:

--- a/src/translator_component_toolkit/config.py
+++ b/src/translator_component_toolkit/config.py
@@ -22,7 +22,7 @@ def http_timeout() -> float:
     """Return the configured HTTP timeout in seconds.
 
     Reads ``TCT_HTTP_TIMEOUT`` when set to a positive number; otherwise falls
-    back to :data:`DEFAULT_HTTP_TIMEOUT`. A missing, unparseable, or
+    back to :data:`DEFAULT_HTTP_TIMEOUT`. A missing, unparsable, or
     non-positive value is treated as "use the default" so a bad env var can
     never disable timeouts.
     """

--- a/src/translator_component_toolkit/schema.py
+++ b/src/translator_component_toolkit/schema.py
@@ -53,6 +53,42 @@ class ParamSpec:
 
 
 @dataclass(frozen=True)
+class ToolAnnotations:
+    """MCP behavioral hints for a tool.
+
+    These mirror the MCP tool-annotations spec and help an agent reason about a
+    tool before calling it. Defaults match the MCP defaults (a tool is assumed
+    writable, destructive, non-idempotent, and open-world unless stated).
+
+    Attributes
+    ----------
+    read_only : bool
+        The tool does not modify any state; it only fetches or computes.
+    destructive : bool
+        Whether the tool may perform irreversible updates. Only meaningful when
+        ``read_only`` is False.
+    idempotent : bool
+        Calling repeatedly with the same arguments has no additional effect.
+    open_world : bool
+        The tool interacts with external services (e.g. makes network calls).
+    """
+
+    read_only: bool = False
+    destructive: bool = True
+    idempotent: bool = False
+    open_world: bool = True
+
+    def to_mcp(self) -> dict[str, bool]:
+        """Render as the ``annotations`` dict accepted by ``FastMCP.tool``."""
+        return {
+            "readOnlyHint": self.read_only,
+            "destructiveHint": self.destructive,
+            "idempotentHint": self.idempotent,
+            "openWorldHint": self.open_world,
+        }
+
+
+@dataclass(frozen=True)
 class ToolSpec:
     """One agent-facing operation.
 
@@ -76,6 +112,8 @@ class ToolSpec:
     paginated : bool
         Whether the tool accepts ``limit``/``offset`` and returns a bounded
         response envelope (see :func:`io.paginate`).
+    annotations : ToolAnnotations
+        MCP behavioral hints surfaced to agents during tool registration.
     """
 
     name: str
@@ -86,6 +124,7 @@ class ToolSpec:
     group: str = "misc"
     output_hint: str | None = None
     paginated: bool = False
+    annotations: ToolAnnotations = field(default_factory=ToolAnnotations)
 
 
 def make_signed_callable(spec: ToolSpec) -> Callable[..., Any]:
@@ -220,6 +259,12 @@ def _trapi_query_endpoint(url: str, query: dict) -> Any:
 # Registry: the single source of truth.
 # ---------------------------------------------------------------------------
 
+# Every tool here fetches or computes and returns a result; none mutate a remote
+# resource or local persistent state, and repeating a call has no extra effect.
+# They differ only in whether they reach out to external services.
+_READ_ONLINE = ToolAnnotations(read_only=True, destructive=False, idempotent=True, open_world=True)
+_READ_LOCAL = ToolAnnotations(read_only=True, destructive=False, idempotent=True, open_world=False)
+
 REGISTRY: list[ToolSpec] = [
     ToolSpec(
         name="lookup_name",
@@ -234,6 +279,7 @@ REGISTRY: list[ToolSpec] = [
             ParamSpec("return_synonyms", bool, default=False, help="Include synonyms in the result."),
         ],
         output_hint="TranslatorNode or list[TranslatorNode]",
+        annotations=_READ_ONLINE,
     ),
     ToolSpec(
         name="get_synonyms",
@@ -243,6 +289,7 @@ REGISTRY: list[ToolSpec] = [
         group="name",
         params=[ParamSpec("query", str, required=True, help="CURIE to get synonyms for.")],
         output_hint="dict[curie, TranslatorNode]",
+        annotations=_READ_ONLINE,
     ),
     ToolSpec(
         name="lookup_names",
@@ -257,6 +304,7 @@ REGISTRY: list[ToolSpec] = [
             ParamSpec("return_synonyms", bool, default=False, help="Include synonyms in the results."),
         ],
         output_hint="dict[str, TranslatorNode]",
+        annotations=_READ_ONLINE,
     ),
     ToolSpec(
         name="normalize_nodes",
@@ -271,6 +319,7 @@ REGISTRY: list[ToolSpec] = [
             ParamSpec("drug_chemical_conflate", bool, default=False, help="Enable drug-chemical conflation."),
         ],
         output_hint="TranslatorNode or dict[curie, TranslatorNode]",
+        annotations=_READ_ONLINE,
     ),
     ToolSpec(
         name="get_kp_info",
@@ -278,6 +327,7 @@ REGISTRY: list[ToolSpec] = [
         func=_get_kp_info,
         group="kp",
         output_hint="tuple[DataFrame, dict[name, url]]",
+        annotations=_READ_ONLINE,
     ),
     ToolSpec(
         name="get_metakg",
@@ -294,6 +344,7 @@ REGISTRY: list[ToolSpec] = [
             ParamSpec("offset", int, default=0, help="Row offset when paginating."),
         ],
         output_hint="DataFrame, or bounded envelope {data, total, returned, truncated, next_offset} when limit/offset given",
+        annotations=_READ_ONLINE,
     ),
     ToolSpec(
         name="add_metakg_api",
@@ -311,6 +362,7 @@ REGISTRY: list[ToolSpec] = [
             ParamSpec("new_api_object", str, required=True, help="Object type for the new API."),
         ],
         output_hint="tuple[dict, DataFrame]",
+        annotations=_READ_LOCAL,
     ),
     ToolSpec(
         name="add_plover_apis",
@@ -323,6 +375,7 @@ REGISTRY: list[ToolSpec] = [
             ParamSpec("metakg_df", Any, required=True, help="Current MetaKG DataFrame."),
         ],
         output_hint="tuple[dict, DataFrame]",
+        annotations=_READ_ONLINE,
     ),
     ToolSpec(
         name="get_api_predicates",
@@ -330,6 +383,7 @@ REGISTRY: list[ToolSpec] = [
         func=_get_api_predicates,
         group="query",
         output_hint="tuple[dict, DataFrame, dict]",
+        annotations=_READ_ONLINE,
     ),
     ToolSpec(
         name="optimize_query",
@@ -344,6 +398,7 @@ REGISTRY: list[ToolSpec] = [
                       help="Map of API names to predicates; omit to use the cached Translator catalog."),
         ],
         output_hint="dict (modified query)",
+        annotations=_READ_LOCAL,
     ),
     ToolSpec(
         name="query_kp",
@@ -360,6 +415,7 @@ REGISTRY: list[ToolSpec] = [
                       help="Map of API names to predicates; omit to use the cached Translator catalog."),
         ],
         output_hint="dict (knowledge graph) or None",
+        annotations=_READ_ONLINE,
     ),
     ToolSpec(
         name="query_kps_parallel",
@@ -377,6 +433,7 @@ REGISTRY: list[ToolSpec] = [
             ParamSpec("max_workers", int, default=1, help="Number of parallel workers."),
         ],
         output_hint="dict (merged knowledge graph)",
+        annotations=_READ_ONLINE,
     ),
     ToolSpec(
         name="query_trapi",
@@ -389,6 +446,7 @@ REGISTRY: list[ToolSpec] = [
             ParamSpec("query", dict, required=True, help="TRAPI query dict (e.g. from trapi.build_query)."),
         ],
         output_hint="dict (result message) or None",
+        annotations=_READ_ONLINE,
     ),
 ]
 

--- a/src/translator_component_toolkit/server.py
+++ b/src/translator_component_toolkit/server.py
@@ -25,6 +25,7 @@ mcp = FastMCP("translator-toolkit")
 def _register(spec: ToolSpec) -> None:
     """Register one tool (and its aliases) on the MCP server from a ToolSpec."""
     base = make_signed_callable(spec)
+    annotations = spec.annotations.to_mcp()
 
     def wrap(name: str, description: str):
         signed = make_signed_callable(spec)
@@ -40,7 +41,7 @@ def _register(spec: ToolSpec) -> None:
         tool_fn.__doc__ = description
         tool_fn.__signature__ = signed.__signature__  # type: ignore[attr-defined]
         tool_fn.__annotations__ = dict(signed.__annotations__)
-        mcp.tool(name=name, description=description)(tool_fn)
+        mcp.tool(name=name, description=description, annotations=annotations)(tool_fn)
 
     wrap(spec.name, spec.summary)
     for alias in spec.aliases:

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -9,6 +9,7 @@ from translator_component_toolkit.errors import InvalidParameterError
 from translator_component_toolkit.schema import (
     REGISTRY,
     ParamSpec,
+    ToolAnnotations,
     ToolSpec,
     all_names,
     make_signed_callable,
@@ -212,3 +213,52 @@ def test_query_kp_explicit_api_names_override_catalog(seeded_catalog):
     # known "API X" is rejected.
     with pytest.raises(InvalidParameterError):
         schema._query_knowledge_provider("API X", {}, api_names={})
+
+
+# ---------------------------------------------------------------------------
+# MCP tool annotations (issue #21).
+# ---------------------------------------------------------------------------
+
+# Tools whose work is purely local (no external service). Everything else in the
+# registry reaches out to the network.
+LOCAL_ONLY_TOOLS = {"optimize_query", "add_metakg_api"}
+
+
+def test_every_tool_has_annotations():
+    for spec in REGISTRY:
+        assert isinstance(spec.annotations, ToolAnnotations)
+
+
+def test_all_tools_are_read_only_and_non_destructive():
+    for spec in REGISTRY:
+        assert spec.annotations.read_only is True, f"{spec.name} should be read-only"
+        assert spec.annotations.destructive is False, f"{spec.name} should be non-destructive"
+        assert spec.annotations.idempotent is True, f"{spec.name} should be idempotent"
+
+
+def test_open_world_matches_network_reach():
+    for spec in REGISTRY:
+        expected = spec.name not in LOCAL_ONLY_TOOLS
+        assert spec.annotations.open_world is expected, f"{spec.name} open_world should be {expected}"
+
+
+def test_to_mcp_renders_spec_hint_keys():
+    annotations = ToolAnnotations(read_only=True, destructive=False, idempotent=True, open_world=False)
+    assert annotations.to_mcp() == {
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": False,
+    }
+
+
+def test_tool_annotations_defaults_match_mcp_defaults():
+    # MCP assumes a tool is writable, destructive, non-idempotent, open-world
+    # unless told otherwise.
+    defaults = ToolAnnotations()
+    assert defaults.to_mcp() == {
+        "readOnlyHint": False,
+        "destructiveHint": True,
+        "idempotentHint": False,
+        "openWorldHint": True,
+    }

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2,13 +2,17 @@
 
 import asyncio
 
-from translator_component_toolkit.schema import all_names
+from translator_component_toolkit.schema import REGISTRY, all_names
 from translator_component_toolkit.server import mcp
 
 
 def _registered_tool_names():
     tools = asyncio.run(mcp.list_tools())
     return {t.name for t in tools}
+
+
+def _registered_tools_by_name():
+    return {t.name: t for t in asyncio.run(mcp.list_tools())}
 
 
 def test_mcp_server_exists():
@@ -42,3 +46,24 @@ def test_deprecated_alias_still_importable():
     from translator_component_toolkit.server import name_lookup
 
     assert callable(name_lookup), "deprecated name_lookup alias should still be accessible"
+
+
+def test_registered_tools_carry_annotations():
+    """Each canonical tool exposes the behavioral hints declared in the registry."""
+    registered = _registered_tools_by_name()
+    for spec in REGISTRY:
+        tool = registered[spec.name]
+        assert tool.annotations is not None, f"{spec.name} missing annotations"
+        assert tool.annotations.readOnlyHint is spec.annotations.read_only
+        assert tool.annotations.destructiveHint is spec.annotations.destructive
+        assert tool.annotations.idempotentHint is spec.annotations.idempotent
+        assert tool.annotations.openWorldHint is spec.annotations.open_world
+
+
+def test_aliases_inherit_canonical_annotations():
+    """A deprecated alias is registered with the same hints as its canonical tool."""
+    registered = _registered_tools_by_name()
+    for spec in REGISTRY:
+        for alias in spec.aliases:
+            assert registered[alias].annotations.readOnlyHint is spec.annotations.read_only
+            assert registered[alias].annotations.openWorldHint is spec.annotations.open_world


### PR DESCRIPTION
## Summary
- Adds a `ToolAnnotations` dataclass (`read_only`/`destructive`/`idempotent`/`open_world`, with a `to_mcp()` renderer) and an `annotations` field on `ToolSpec`.
- Annotates all 13 registry tools and passes the hints through MCP registration (`mcp.tool(..., annotations=...)`), so aliases inherit their canonical tool's hints.

Classification:
- All tools are read-only, non-destructive, idempotent (they fetch/compute and return; none mutate a remote resource or local persistent state).
- `openWorldHint` is true for tools that contact external services, false for the two purely-local transforms: `optimize_query`, `add_metakg_api`.

This lets an agent see which tools are safe to call without confirmation and which reach the network. No behavior change to the tools themselves.

Closes #21

## Notes
- Stacked on `feat/http-timeouts` (PR #19).

## Test plan
- [x] Every tool has a `ToolAnnotations`; all are read-only/non-destructive/idempotent
- [x] `open_world` matches network reach (local-only set vs. the rest)
- [x] `to_mcp()` renders the four MCP hint keys; defaults match MCP defaults
- [x] Registered MCP tools (and their aliases) carry the declared hints
- [x] Full suite: 121 passed, 1 skipped
- [x] `ruff check` clean on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)